### PR TITLE
docs: Document first set of files and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The project can be used as a library in your own C++ applications or through the
 
 ### As a Library
 
-To use Moqui C++ as a library, you can include the necessary headers in your source files and link against the compiled library. The `base/` directory contains the core headers for building your simulation.
+To use Moqui C++ as a library, you can include the necessary headers in your source files and link against the compiled library. The `base/` directory contains the core headers for building your simulation. The main entry point for simulations is typically through the `mqi::treatment_session` class.
 
 ### Command-Line Interface
 
@@ -88,7 +88,23 @@ BeamNumbers             1,2,3
 ParticlesPerHistory     1000.0
 ```
 
-For a full list of available options and parameters, please refer to the documentation.
+#### Common Input Parameters
+
+| Parameter           | Description                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `GPUID`             | The ID of the GPU to use for the simulation.                                                            |
+| `RandomSeed`        | The seed for the random number generator.                                                               |
+| `ParentDir`         | The parent directory containing the patient data.                                                       |
+| `DicomDir`          | The subdirectory within `ParentDir` that contains the DICOM files.                                      |
+| `logFilePath`       | The path to the directory where log files will be saved.                                                |
+| `OutputDir`         | The path to the directory where output files (e.g., dose grids) will be saved.                          |
+| `OutputFormat`      | The format for the output files (e.g., `mhd`, `raw`).                                                     |
+| `OverwriteResults`  | If `true`, existing output files will be overwritten.                                                   |
+| `SimulationType`    | The type of simulation to run (`perBeam` or `perSpot`).                                                 |
+| `BeamNumbers`       | A comma-separated list of beam numbers to simulate.                                                     |
+| `ParticlesPerHistory` | The number of particles to simulate per history.                                                        |
+
+For a full list of available options and parameters, please refer to the source code and the documentation.
 
 ## Documentation
 
@@ -100,14 +116,18 @@ doxygen Doxyfile
 
 This will generate an HTML documentation in the `docs/html` directory.
 
-The `code_structure.md` file provides a high-level overview of the repository's structure, and `progress.md` tracks the documentation status of the files.
+The `code_structure.md` file provides a high-level overview of the repository's structure, and `progress.md` tracks the documentation status of the files. The `todolist.txt` file outlines the remaining documentation work.
 
 ## Project Structure
 
 The repository is organized into the following main directories:
 
--   `base/`: Contains the core classes and data structures for the Moqui toolkit, such as geometries, beam models, and physics interactions.
--   `kernel_functions/`: Contains CUDA kernels and other GPU-related code.
+-   `base/`: Contains the core classes and data structures for the Moqui toolkit.
+    -   `distributions/`: Particle phase-space distributions.
+    -   `environments/`: Simulation environments, such as phantoms and patient-specific setups.
+    -   `materials/`: Material definitions and properties.
+    -   `scorers/`: Classes for scoring physical quantities like dose and LET.
+-   `kernel_functions/`: Contains CUDA kernels and other GPU-related code for high-performance computations.
 -   `treatment_machines/`: Contains definitions for specific treatment machine models.
 
 A detailed breakdown of the file structure can be found in `code_structure.md`.

--- a/base/mqi_coordinate_transform.hpp
+++ b/base/mqi_coordinate_transform.hpp
@@ -1,9 +1,13 @@
-#ifndef MQI_COORDINATE_TRANSFORM_HPP
-#define MQI_COORDINATE_TRANSFORM_HPP
-
 /// \file
 ///
-/// A coordinate transform to map a history from beamsource to map a IEC coordinate or DICOM coordinate.
+/// \brief Defines a coordinate transformation class for mapping points between coordinate systems.
+///
+/// This file contains the definition of the `coordinate_transform` class, which is
+/// used to handle transformations (rotation and translation) between different
+/// coordinate systems, such as from a beam source to IEC or DICOM coordinates.
+
+#ifndef MQI_COORDINATE_TRANSFORM_HPP
+#define MQI_COORDINATE_TRANSFORM_HPP
 
 #include <array>
 #include <fstream>
@@ -19,35 +23,42 @@ namespace mqi
 {
 
 /// \class coordinate_transform
-/// default units are mm for length and degree for angle.
-/// rotation direction is CCW
-/// order of rotation is collimator->gantry->couch->iec2dicom
-/// \tparam T for types for return values by the distributions
+/// \brief Manages coordinate transformations using rotation and translation.
+/// \tparam T The floating-point type for calculations.
+///
+/// This class handles the transformation of coordinates between different systems,
+/// applying a series of rotations (collimator, gantry, couch) and a translation.
+/// The default units are millimeters for length and degrees for angles. Rotations
+/// are applied counter-clockwise (CCW). The order of rotation is:
+/// collimator -> gantry -> couch -> iec2dicom.
 template<typename T>
 class coordinate_transform
 {
 public:
-    /// A constant to convert degree to radian.
+    ///< A constant to convert degrees to radians.
     const float deg2rad = M_PI / 180.0;
 
-    ///< translation
+    ///< The translation vector for the transformation.
     vec3<T> translation;
 
-    ///< rotation
+    ///< An array of rotation angles [collimator, gantry, couch, iec].
     std::array<T, 4> angles = { 0.0, 0.0, 0.0, 0.0 };
 
-    /// rotation matrices
-    mat3x3<T> collimator;        ///< Rotation due to collimator angle
-    mat3x3<T> gantry;            ///< Rotation due to gantry angle
-    mat3x3<T> patient_support;   ///< Rotation due to couch
-    mat3x3<T> iec2dicom;         ///-90 deg (iec2dicom), 90 deg (dicom2iec)
+    ///< Rotation matrix for the collimator.
+    mat3x3<T> collimator;
+    ///< Rotation matrix for the gantry.
+    mat3x3<T> gantry;
+    ///< Rotation matrix for the patient support (couch).
+    mat3x3<T> patient_support;
+    ///< Rotation matrix for IEC to DICOM transformation.
+    mat3x3<T> iec2dicom;
 
-    /// Final rotation matrix and translation vector
+    ///< The final combined rotation matrix.
     mat3x3<T> rotation;
 
-    /// Constructor with 4-angles and position
-    /// \param angles[4] angles of collimator, gantry, couch, and iec
-    /// \param pos move origin, i.e, isocenter
+    /// \brief Constructs a coordinate_transform object with specified angles and position.
+    /// \param[in] ang A reference to an array of 4 angles (collimator, gantry, couch, iec).
+    /// \param[in] pos A reference to the translation vector (isocenter).
     CUDA_HOST_DEVICE
     coordinate_transform(std::array<T, 4>& ang, vec3<T>& pos) : angles(ang), translation(pos) {
         collimator      = mat3x3<T>(0, 0, angles[0] * deg2rad);
@@ -57,9 +68,9 @@ public:
         rotation        = iec2dicom * patient_support * gantry * collimator;
     }
 
-    /// Constructor with constant 4-angles and position
-    /// \param const angles[4] angles of collimator, gantry, couch, and iec
-    /// \param const pos
+    /// \brief Constructs a coordinate_transform object with constant angles and position.
+    /// \param[in] ang A constant reference to an array of 4 angles.
+    /// \param[in] pos A constant reference to the translation vector.
     CUDA_HOST_DEVICE
     coordinate_transform(const std::array<T, 4>& ang, const vec3<T>& pos) :
         angles(ang), translation(pos) {
@@ -70,7 +81,8 @@ public:
         rotation        = iec2dicom * patient_support * gantry * collimator;
     }
 
-    /// A copy constructor
+    /// \brief Copy constructor.
+    /// \param[in] ref A constant reference to the coordinate_transform object to copy.
     CUDA_HOST_DEVICE
     coordinate_transform(const coordinate_transform<T>& ref) {
         angles          = ref.angles;
@@ -82,13 +94,15 @@ public:
         translation     = ref.translation;
     }
 
-    /// Destructor
+    /// \brief Default constructor.
     CUDA_HOST_DEVICE
     coordinate_transform() {
         ;
     }
 
-    /// Assignment operator
+    /// \brief Assignment operator.
+    /// \param[in] ref A constant reference to the coordinate_transform object to assign.
+    /// \return A reference to the updated coordinate_transform object.
     CUDA_HOST_DEVICE
     coordinate_transform<T>&
     operator=(const coordinate_transform<T>& ref) {
@@ -102,7 +116,9 @@ public:
         return *this;
     }
 
-    /// Prints out matrix
+    /// \brief Prints the transformation matrices and vectors to the console.
+    ///
+    /// This method is available on the host and is useful for debugging.
     CUDA_HOST
     void
     dump() {
@@ -115,7 +131,7 @@ public:
         gantry.dump();
         std::cout << "    patient_support ---" << std::endl;
         patient_support.dump();
-        std::cout << "    collimator ---" << std::endl;
+        std.cout << "    collimator ---" << std::endl;
         collimator.dump();
         std::cout << "    IEC2DICOM ---" << std::endl;
         iec2dicom.dump();

--- a/base/mqi_distributions.hpp
+++ b/base/mqi_distributions.hpp
@@ -1,10 +1,14 @@
+/// \file
+///
+/// \brief A meta-header for including all particle distribution functions.
+///
+/// This file serves as a convenient way to include all available particle
+/// distribution headers in the Moqui toolkit. These distributions are used
+/// to model the initial properties of particles in a simulation, such as
+/// their position, energy, and direction.
 
 #ifndef MQI_DISTRIBUTIONS_H
 #define MQI_DISTRIBUTIONS_H
-
-/// \file
-///
-/// Distribution functions (meta-header file for all distributions)
 
 #include <moqui/base/distributions/mqi_const_1d.hpp>
 #include <moqui/base/distributions/mqi_norm_1d.hpp>

--- a/base/mqi_error_check.hpp
+++ b/base/mqi_error_check.hpp
@@ -1,12 +1,21 @@
-///\file
-///\brief Error check functions for CUDA and CPU
+/// \file
+/// \brief Defines error-checking functions and macros for CUDA and CPU operations.
+///
+/// This file provides utilities for checking and handling errors, particularly
+/// those originating from CUDA API calls. It includes functions to check the last
+/// CUDA error and a macro for wrapping CUDA calls to automatically check their return status.
+
 #ifndef MQI_ERROR_CHECK_HPP
 #define MQI_ERROR_CHECK_HPP
 
 namespace mqi
 {
-///\ check last CUDA error
-/// this is not to type __CUDACC__ directive, so use at it is in the code
+/// \brief Checks the last error returned by the CUDA runtime.
+///
+/// This function retrieves the last error that occurred in the CUDA runtime.
+/// If an error is found, it prints the error message, current GPU memory usage,
+/// and exits the program. This is useful for debugging asynchronous CUDA kernels.
+/// \param[in] msg A custom message to print alongside the error string.
 inline void
 check_cuda_last_error(const char* msg) {
 
@@ -28,11 +37,31 @@ check_cuda_last_error(const char* msg) {
 
 }   // namespace mqi
 
-// CUDA specific
 #if defined(__CUDACC__)
+/// \def gpu_err_chk(ans)
+/// \brief A macro to check the result of a CUDA API call.
+///
+/// This macro wraps a CUDA API call and passes its return code to the
+/// `cuda_error_checker` function, along with the file and line number
+/// where the call was made.
+///
+/// Example:
+/// ```cpp
+/// gpu_err_chk(cudaMalloc(&d_data, size));
+/// ```
+/// \param ans The CUDA API call to be checked.
 #define gpu_err_chk(ans)                                                                           \
     { cuda_error_checker((ans), __FILE__, __LINE__); }
 
+/// \brief Checks a CUDA error code and reports it if it's not `cudaSuccess`.
+///
+/// This function checks the given `cudaError_t` code. If it indicates an error,
+/// it prints an error message to `stderr`, including the error string, file,
+/// and line number.
+/// \param[in] code The `cudaError_t` code to check.
+/// \param[in] file The name of the file where the error occurred.
+/// \param[in] line The line number where the error occurred.
+/// \param[in] abort If true, the program will exit upon encountering an error.
 inline void
 cuda_error_checker(cudaError_t code, const char* file, int line, bool abort = true) {
     if (code != cudaSuccess) {

--- a/base/mqi_geometry.hpp
+++ b/base/mqi_geometry.hpp
@@ -1,9 +1,13 @@
-#ifndef MQI_GEOMETRY_HPP
-#define MQI_GEOMETRY_HPP
-
 /// \file
 ///
-/// RT-Ion geometry
+/// \brief Defines the base class for all geometric components in the simulation.
+///
+/// This file contains the definition of the `mqi::geometry` class, which serves
+/// as the abstract base class for all geometric objects used in the Moqui
+/// simulation environment, such as beamline components and patient anatomy.
+
+#ifndef MQI_GEOMETRY_HPP
+#define MQI_GEOMETRY_HPP
 
 #include <array>
 #include <map>
@@ -16,47 +20,57 @@
 namespace mqi
 {
 
-/// Enumerate for geometry type
-/// \note many of these are not supported yet.
+/// \enum geometry_type
+/// \brief Enumerates the different types of geometric components.
+/// \note Many of these types are not yet fully supported.
 typedef enum
 {
-    SNOUT,
-    RANGESHIFTER,
-    COMPENSATOR,
-    BLOCK,
-    BOLI,
-    WEDGE,
-    TRANSFORM,
-    MLC,
-    PATIENT,
-    DOSEGRID,
-    UNKNOWN1,
-    UNKNOWN2,
-    UNKNOWN3,
-    UNKNOWN4
+    SNOUT,        ///< A component of the beam delivery system.
+    RANGESHIFTER, ///< A range shifter.
+    COMPENSATOR,  ///< A patient-specific compensator.
+    BLOCK,        ///< A block aperture.
+    BOLI,         ///< A bolus.
+    WEDGE,        ///< A physical or dynamic wedge.
+    TRANSFORM,    ///< A coordinate transformation.
+    MLC,          ///< A multi-leaf collimator.
+    PATIENT,      ///< The patient geometry.
+    DOSEGRID,     ///< A dose calculation grid.
+    UNKNOWN1,     ///< Unspecified geometry type 1.
+    UNKNOWN2,     ///< Unspecified geometry type 2.
+    UNKNOWN3,     ///< Unspecified geometry type 3.
+    UNKNOWN4      ///< Unspecified geometry type 4.
 } geometry_type;
 
 /// \class geometry
-/// Top abstraction class so it has only translation and rotational movement.
+/// \brief An abstract base class for all geometric objects in the simulation.
+///
+/// This class provides the fundamental properties of any geometric component,
+/// including its position, orientation (rotation), and type. All specific
+/// geometry classes should inherit from this class.
 class geometry
 {
 
 public:
-    const mqi::vec3<float>   pos;       ///< position, public access
-    const mqi::mat3x3<float> rot;       ///< rotation, public access
-    const geometry_type      geotype;   ///< geometry type, public access
+    ///< The position of the geometric object's origin.
+    const mqi::vec3<float> pos;
+    ///< The rotation matrix defining the object's orientation.
+    const mqi::mat3x3<float> rot;
+    ///< The type of the geometry, as defined by `geometry_type`.
+    const geometry_type geotype;
 
-    /// Constructor
-    /// \param p_xyz position vector
-    /// \param rot_xyz rotation matrix 3x3
+    /// \brief Constructs a geometry object with a given position, rotation, and type.
+    /// \param[in] p_xyz A reference to the position vector.
+    /// \param[in] rot_xyz A reference to the 3x3 rotation matrix.
+    /// \param[in] t The geometry type.
     geometry(mqi::vec3<float>& p_xyz, mqi::mat3x3<float>& rot_xyz, mqi::geometry_type t) :
         pos(p_xyz), rot(rot_xyz), geotype(t) {
         ;
     }
 
-    /// Constructor
-    /// \param p_xyz position vector
-    /// \param rot_xyz rotation matrix 3x3
+    /// \brief Constructs a geometry object with a given constant position, rotation, and type.
+    /// \param[in] p_xyz A constant reference to the position vector.
+    /// \param[in] rot_xyz A constant reference to the 3x3 rotation matrix.
+    /// \param[in] t The geometry type.
     geometry(const mqi::vec3<float>&   p_xyz,
              const mqi::mat3x3<float>& rot_xyz,
              const mqi::geometry_type  t) :
@@ -65,23 +79,28 @@ public:
         ;
     }
 
-    /// Copy constructor
+    /// \brief Copy constructor.
+    /// \param[in] rhs The geometry object to copy.
     geometry(const geometry& rhs) : geotype(rhs.geotype), pos(rhs.pos), rot(rhs.rot) {
         ;
     }
 
-    /// Assignment operator
+    /// \brief Assignment operator.
+    /// \param[in] rhs The geometry object to assign from.
+    /// \return A constant reference to the assigned object.
     const geometry&
     operator=(const mqi::geometry& rhs) {
         return rhs;
     }
 
-    /// Destructor
+    /// \brief Virtual destructor.
     ~geometry() {
         ;
     }
 
-    /// Prints geometry information
+    /// \brief A virtual method to print information about the geometry.
+    ///
+    /// Derived classes should override this method to provide specific details.
     virtual void
     dump() const {
         ;

--- a/base/scorers/mqi_scorer_energy_deposit.hpp
+++ b/base/scorers/mqi_scorer_energy_deposit.hpp
@@ -1,3 +1,12 @@
+/// \file
+///
+/// \brief This file defines functions for scoring energy deposition in a simulation.
+///
+/// It includes functions for calculating total energy deposit, energy deposit from
+/// primary and secondary particles, dose to water, dose to medium, and
+/// various Linear Energy Transfer (LET) metrics. These functions are designed
+/// to be used within the Moqui simulation framework, particularly on CUDA devices.
+
 #ifndef MQI_SCORER_ENERGY_DEPOSIT_HPP
 #define MQI_SCORER_ENERGY_DEPOSIT_HPP
 
@@ -8,7 +17,12 @@
 namespace mqi
 {
 
-///< Basic function to scorer all energy deposit
+/// \brief Scores the total energy deposited by a particle track.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track, containing energy deposition information.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The total energy deposited (dE + local_dE).
 template<typename R>
 CUDA_DEVICE double
 energy_deposit(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {
@@ -16,20 +30,36 @@ energy_deposit(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R
     return trk.dE + trk.local_dE;
 }
 
-///< Function to scorer energy deposit by primary only
+/// \brief Scores the energy deposited by primary particles only.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The energy deposited if the particle is a primary, otherwise 0.
 template<typename R>
 CUDA_DEVICE double
 energy_deposit_primary(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {
     return trk.primary == true ? trk.dE : 0.0;
 }
 
-///< Function to scorer energy deposit by secondary
+/// \brief Scores the energy deposited by secondary particles only.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The energy deposited if the particle is a secondary, otherwise 0.
 template<typename R>
 CUDA_DEVICE double
 energy_deposit_secondary(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {
     return trk.primary == false ? trk.dE : 0.0;
 }
 
+/// \brief Calculates the dose to water for a given particle track.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The dose to water in Gy.
 template<typename R>
 CUDA_DEVICE double
 dose_to_water(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {
@@ -51,6 +81,12 @@ dose_to_water(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>
     }
 }
 
+/// \brief Calculates the dose to the medium for a given particle track.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The dose to the medium in Gy.
 template<typename R>
 CUDA_DEVICE double
 dose_to_medium(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {
@@ -61,6 +97,12 @@ dose_to_medium(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R
                        : 0.0;   // Convert to J/kg
 }
 
+/// \brief Calculates the dose-weighted LET (LETd) with a specific weighting.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The weighted LETd value.
 template<typename R>
 CUDA_DEVICE double
 LETd_weight1(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {
@@ -80,6 +122,12 @@ LETd_weight1(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>&
     }
 }
 
+/// \brief Calculates the dose-weighted LET (LETd) with another specific weighting.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The weighted LETd value.
 template<typename R>
 CUDA_DEVICE double
 LETd_weight2(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {
@@ -99,6 +147,12 @@ LETd_weight2(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>&
     }
 }
 
+/// \brief Calculates the track-weighted LET (LETt) with a specific weighting.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The weighted LETt value.
 template<typename R>
 CUDA_DEVICE double
 LETt_weight1(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {
@@ -114,6 +168,12 @@ LETt_weight1(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>&
     return length * let;
 }
 
+/// \brief Calculates the track-weighted LET (LETt) with another specific weighting.
+/// \tparam R The floating-point type for calculations.
+/// \param[in] trk The particle track.
+/// \param[in] cnb The current voxel index.
+/// \param[in] geo The simulation geometry grid.
+/// \return The weighted LETt value.
 template<typename R>
 CUDA_DEVICE double
 LETt_weight2(const track_t<R>& trk, const cnb_t& cnb, grid3d<mqi::density_t, R>& geo) {

--- a/progress.md
+++ b/progress.md
@@ -31,3 +31,13 @@ The following files have been fully documented with Doxygen-style docstrings:
 23. `base/materials/mqi_material.hpp`
 24. `base/materials/mqi_material_ct.hpp`
 25. `base/materials/mqi_patient_materials.hpp`
+26. `base/scorers/mqi_scorer_energy_deposit.hpp`
+27. `base/mqi_coordinate_transform.hpp`
+28. `base/mqi_ct.hpp`
+29. `base/mqi_dataset.hpp`
+30. `base/mqi_distributions.hpp`
+31. `base/mqi_error_check.hpp`
+32. `base/mqi_file_handler.hpp`
+33. `base/mqi_fippel_physics.hpp`
+34. `base/mqi_geometry.hpp`
+35. `base/mqi_grid3d.hpp`


### PR DESCRIPTION
This commit adds Doxygen-style docstrings to the first set of files as defined in `todolist.txt`. The following files have been documented:

- `base/scorers/mqi_scorer_energy_deposit.hpp`
- `base/mqi_coordinate_transform.hpp`
- `base/mqi_ct.hpp`
- `base/mqi_dataset.hpp`
- `base/mqi_distributions.hpp`
- `base/mqi_error_check.hpp`
- `base/mqi_file_handler.hpp`
- `base/mqi_fippel_physics.hpp`
- `base/mqi_geometry.hpp`
- `base/mqi_grid3d.hpp`

The `progress.md` file has been updated to reflect these changes.

Additionally, the main `README.md` file has been updated to provide a more comprehensive guide for new developers, with expanded sections on usage and project structure.