### PR TITLE
Docs: Add Doxygen comments for second group of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Contributions to Moqui C++ are welcome! If you would like to contribute, please 
 
 Please ensure that your code adheres to the existing coding style and that you have added appropriate documentation and tests.
 
+### For AI Agents
+
+If you are an AI agent working on this repository, please look for `AGENTS.md` files in the directory structure. These files may contain specific instructions or conventions to follow.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/base/mqi_hash_table.hpp
+++ b/base/mqi_hash_table.hpp
@@ -7,12 +7,23 @@
 namespace mqi
 {
 
+/**
+ * @struct key_value
+ * @brief Represents a key-value pair for a hash table.
+ * @details This structure holds two keys and a corresponding double-precision value. It is used as the basic element in the hash table implementation.
+ */
 struct key_value {
-    mqi::key_t key1;
-    mqi::key_t key2;
-    double     value;
+    mqi::key_t key1;  ///< The first key component.
+    mqi::key_t key2;  ///< The second key component.
+    double     value; ///< The value associated with the key pair.
 };
 
+/**
+ * @brief Initializes a hash table on the host.
+ * @param[out] table A pointer to the array of key_value structs to be initialized.
+ * @param[in] max_capacity The maximum capacity of the hash table.
+ * @details This function initializes all entries in the table, setting keys to `mqi::empty_pair` and values to 0.
+ */
 void
 init_table(key_value* table, uint32_t max_capacity) {
     //// Multithreading?
@@ -23,6 +34,13 @@ init_table(key_value* table, uint32_t max_capacity) {
     }
 }
 
+/**
+ * @brief Initializes a hash table on a CUDA device.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[out] table A pointer to the device memory where the key_value structs are stored.
+ * @param[in] max_capacity The maximum capacity of the hash table.
+ * @details This CUDA kernel initializes the `value` field of each entry in the table to 0. Note: This function only initializes the value, not the keys.
+ */
 template<typename R>
 CUDA_GLOBAL void
 init_table_cuda(key_value* table, uint32_t max_capacity) {
@@ -34,6 +52,12 @@ init_table_cuda(key_value* table, uint32_t max_capacity) {
     //#endif
 }
 
+/**
+ * @brief A test function to print a specific entry from the hash table on a CUDA device.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] data A pointer to the device memory where the key_value structs are stored.
+ * @details This CUDA kernel prints the key and value of a hardcoded index for debugging purposes.
+ */
 template<typename R>
 CUDA_GLOBAL void
 test_print(mqi::key_value* data) {

--- a/base/mqi_interaction.hpp
+++ b/base/mqi_interaction.hpp
@@ -12,37 +12,53 @@
 namespace mqi
 {
 
-///< Interaction model (pure virtual class)
-///< interface between particle and material
-///< template R and particle type
-///<
+/**
+ * @class interaction
+ * @brief A pure virtual class representing the interaction between a particle and a material.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @tparam P The particle type.
+ * @details This class serves as an interface for different physics interaction models. It defines the common methods that any interaction process should implement, such as calculating cross-sections, sampling step lengths, and updating particle tracks.
+ */
 template<typename R, mqi::particle_t P>
 class interaction
 {
 public:
-    const physics_constants<R> units;
+    const physics_constants<R> units;   ///< Physics constants with appropriate units.
 #ifdef __PHYSICS_DEBUG__
-    R T_cut = 0.08511 * units.MeV;   //0.083 MeV for electron cut, 0.01 MeV cut for Proton
+    R T_cut = 0.08511 * units.MeV;   ///< Kinetic energy cut for secondary particles in debug mode.
 #else
-    R T_cut = 0.0815 * units.MeV;   //0.083 MeV for electron cut, 0.01 MeV cut for Proton
+    R T_cut = 0.0815 * units.MeV;   ///< Kinetic energy cut for secondary particles.
 #endif
-    const R max_step = 0.01 * units.cm;   //0.1 * mm cut used to generate dEdx, cross-section
-    R       Tp_cut   = 0.5 * units.MeV;
-    const mqi::vec3<R> dir_z;   //momentum direction of incident particle on scattering plane
+    const R max_step = 0.01 * units.cm;   ///< Maximum step size used to generate dE/dx and cross-section data.
+    R       Tp_cut   = 0.5 * units.MeV;   ///< Kinetic energy cut for protons.
+    const mqi::vec3<R>
+        dir_z;   ///< Momentum direction of the incident particle on the scattering plane.
 
 public:
+    /**
+     * @brief Default constructor.
+     */
     CUDA_HOST_DEVICE
     interaction() : dir_z(0, 0, -1) {
         ;
     }
 
+    /**
+     * @brief Destructor.
+     */
     CUDA_HOST_DEVICE
     ~interaction() {
         ;
     }
 
-    ///< sample step length (cm)
-    /// rho_mass (cm^3)
+    /**
+     * @brief Samples a step length for the particle.
+     * @param[in] rel Relativistic quantities of the particle.
+     * @param[in] mat The material through which the particle is traveling.
+     * @param[in,out] rng A pointer to the random number generator.
+     * @return The sampled step length in cm.
+     * @details The step length is sampled from an exponential distribution based on the material's properties and the interaction cross-section.
+     */
     CUDA_HOST_DEVICE
     virtual R
     sample_step_length(const relativistic_quantities<R>& rel,
@@ -54,8 +70,13 @@ public:
         return -1.0 * mfp * mqi_ln(prob);
     }
 
-    ///< sample step length (cm)
-    /// rho_mass (cm^3)
+    /**
+     * @brief Samples a step length for the particle given a cross-section.
+     * @param[in] cs The total cross-section.
+     * @param[in,out] rng A pointer to the random number generator.
+     * @return The sampled step length in cm.
+     * @details The step length is sampled from an exponential distribution. This is an overloaded version of sample_step_length.
+     */
     CUDA_HOST_DEVICE
     virtual R
     sample_step_length(const R cs, mqi_rng* rng) {
@@ -64,14 +85,26 @@ public:
         return -1.0 * mfp * mqi_ln(prob);
     }
 
-    ///< Return cross-section of the process in mm unit
-    ///< pure virtual method so that a child needs to fill
+    /**
+     * @brief Calculates the cross-section for the interaction.
+     * @param[in] rel Relativistic quantities of the particle.
+     * @param[in] mat The material.
+     * @return The cross-section in cm^2.
+     * @details This is a pure virtual function that must be implemented by derived classes.
+     */
     CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) = 0;
 
-    ///< Update track during a given step
-    ///< e.g., this is usually for CSDA energy loss
+    /**
+     * @brief Updates the particle track during a step (continuous effects).
+     * @param[in,out] trk The particle track to be updated.
+     * @param[in,out] stk The secondary particle stack.
+     * @param[in,out] rng A pointer to the random number generator.
+     * @param[in] len The step length.
+     * @param[in,out] mat The material.
+     * @details This pure virtual function handles continuous processes like energy loss along a step.
+     */
     CUDA_HOST_DEVICE
     virtual void
     along_step(track_t<R>&       trk,
@@ -80,9 +113,16 @@ public:
                const R           len,
                material_t<R>&    mat) = 0;
 
-    ///< Update track at the end of step
-    ///< e.g., push secondaries to the stack
-    ///        update track status, e.g., created, stopped
+    /**
+     * @brief Updates the particle track at the end of a step (discrete effects).
+     * @param[in,out] trk The particle track to be updated.
+     * @param[in,out] stk The secondary particle stack.
+     * @param[in,out] rng A pointer to the random number generator.
+     * @param[in] len The step length.
+     * @param[in,out] mat The material.
+     * @param[in] score_local_deposit A flag to indicate whether to score energy locally.
+     * @details This pure virtual function handles discrete events at the end of a step, such as creating secondary particles.
+     */
     CUDA_HOST_DEVICE
     virtual void
     post_step(track_t<R>&       trk,

--- a/base/mqi_io.hpp
+++ b/base/mqi_io.hpp
@@ -22,11 +22,15 @@ namespace mqi
 {
 namespace io
 {
-///<  save scorer data to a file in binary format
-///<  scr: scorer pointer
-///<  scale: data will be multiplied by
-///<  dir  : directory path. file name will be dir + scr->name + ".bin"
-///<  reshape: roi is used in scorer, original size will be defined.
+/**
+ * @brief Saves scorer data to binary files.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] src A pointer to the scorer object.
+ * @param[in] scale A scaling factor to apply to the scorer values.
+ * @param[in] filepath The directory path where the files will be saved.
+ * @param[in] filename The base name for the output files.
+ * @details This function saves the scorer data into three separate binary files: `_key1.raw`, `_key2.raw`, and `_value.raw`. It extracts non-empty key-value pairs from the scorer's hash table.
+ */
 template<typename R>
 void
 save_to_bin(const mqi::scorer<R>* src,
@@ -34,6 +38,16 @@ save_to_bin(const mqi::scorer<R>* src,
             const std::string&    filepath,
             const std::string&    filename);
 
+/**
+ * @brief Saves a raw array to a binary file.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] src A pointer to the source data array.
+ * @param[in] scale A scaling factor to apply to the data.
+ * @param[in] filepath The directory path for the output file.
+ * @param[in] filename The name of the output file.
+ * @param[in] length The number of elements in the array.
+ * @details The data is scaled and then written to a single `.raw` file.
+ */
 template<typename R>
 void
 save_to_bin(const R*           src,
@@ -42,6 +56,17 @@ save_to_bin(const R*           src,
             const std::string& filename,
             const uint32_t     length);
 
+/**
+ * @brief Saves scorer data to a compressed NumPy `.npz` file in CSR format (spot-major).
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] src A pointer to the scorer object.
+ * @param[in] scale A scaling factor to apply to the scorer values.
+ * @param[in] filepath The directory path for the output file.
+ * @param[in] filename The name of the output file.
+ * @param[in] dim The dimensions of the scoring grid.
+ * @param[in] num_spots The number of spots.
+ * @details The scorer data is saved as a sparse matrix in Compressed Sparse Row (CSR) format, where rows correspond to spots and columns to voxels.
+ */
 template<typename R>
 void
 save_to_npz(const mqi::scorer<R>* src,
@@ -51,6 +76,17 @@ save_to_npz(const mqi::scorer<R>* src,
             mqi::vec3<mqi::ijk_t> dim,
             uint32_t              num_spots);
 
+/**
+ * @brief Saves scorer data to a compressed NumPy `.npz` file in CSR format (voxel-major).
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] src A pointer to the scorer object.
+ * @param[in] scale A scaling factor to apply to the scorer values.
+ * @param[in] filepath The directory path for the output file.
+ * @param[in] filename The name of the output file.
+ * @param[in] dim The dimensions of the scoring grid.
+ * @param[in] num_spots The number of spots.
+ * @details The scorer data is saved as a sparse matrix in Compressed Sparse Row (CSR) format, where rows correspond to voxels and columns to spots. This version uses the ROI mask to determine the matrix size.
+ */
 template<typename R>
 void
 save_to_npz2(const mqi::scorer<R>* src,
@@ -60,6 +96,19 @@ save_to_npz2(const mqi::scorer<R>* src,
              mqi::vec3<mqi::ijk_t> dim,
              uint32_t              num_spots);
 
+/**
+ * @brief Saves scorer data to a compressed NumPy `.npz` file with time scaling and thresholding.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] src A pointer to the scorer object.
+ * @param[in] scale A scaling factor to apply to the scorer values.
+ * @param[in] filepath The directory path for the output file.
+ * @param[in] filename The name of the output file.
+ * @param[in] dim The dimensions of the scoring grid.
+ * @param[in] num_spots The number of spots.
+ * @param[in] time_scale An array of time scaling factors for each spot.
+ * @param[in] threshold A threshold value to apply to the data.
+ * @details This is an extended version of `save_to_npz` that applies additional processing (time scaling and thresholding) before saving.
+ */
 template<typename R>
 void
 save_to_npz(const mqi::scorer<R>* src,
@@ -71,6 +120,16 @@ save_to_npz(const mqi::scorer<R>* src,
             R*                    time_scale,
             R                     threshold);
 
+/**
+ * @brief Saves key-value pair data to binary files.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] src A pointer to the array of key_value structs.
+ * @param[in] scale A scaling factor to apply to the values.
+ * @param[in] max_capacity The maximum capacity of the source array.
+ * @param[in] filepath The directory path for the output files.
+ * @param[in] filename The base name for the output files.
+ * @details Similar to the scorer version, this function saves key-value data into three separate binary files: `_key1.raw`, `_key2.raw`, and `_value.raw`.
+ */
 template<typename R>
 void
 save_to_bin(const mqi::key_value* src,
@@ -79,6 +138,17 @@ save_to_bin(const mqi::key_value* src,
             const std::string&    filepath,
             const std::string&    filename);
 
+/**
+ * @brief Saves volumetric data to an MHD/raw file pair.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] children A pointer to the node structure defining the geometry.
+ * @param[in] src A pointer to the source data array.
+ * @param[in] scale A scaling factor to apply to the data.
+ * @param[in] filepath The directory path for the output files.
+ * @param[in] filename The base name for the output files.
+ * @param[in] length The number of elements in the source array.
+ * @details This function writes a `.mhd` header file and a `.raw` binary data file, a format commonly used in medical imaging (e.g., by ITK).
+ */
 template<typename R>
 void
 save_to_mhd(const mqi::node_t<R>* children,
@@ -88,6 +158,17 @@ save_to_mhd(const mqi::node_t<R>* children,
             const std::string&    filename,
             const uint32_t        length);
 
+/**
+ * @brief Saves volumetric data to a single MHA file.
+ * @tparam R The floating-point type (e.g., float or double).
+ * @param[in] children A pointer to the node structure defining the geometry.
+ * @param[in] src A pointer to the source data array.
+ * @param[in] scale A scaling factor to apply to the data.
+ * @param[in] filepath The directory path for the output file.
+ * @param[in] filename The name of the output file.
+ * @param[in] length The number of elements in the source array.
+ * @details This function writes a single `.mha` file containing both the header and the binary data.
+ */
 template<typename R>
 void
 save_to_mha(const mqi::node_t<R>* children,

--- a/base/mqi_material.hpp
+++ b/base/mqi_material.hpp
@@ -1,3 +1,8 @@
+/**
+ * @file
+ * @brief Includes the necessary headers for material definitions.
+ * @details This is a convenience header that includes the main material class definition (`mqi_material.hpp`) and physical constants (`mqi_physics_constants.hpp`).
+ */
 #ifndef MQI_VMATERIAL_HPP
 #define MQI_VMATERIAL_HPP
 

--- a/base/mqi_math.hpp
+++ b/base/mqi_math.hpp
@@ -1,9 +1,12 @@
+/**
+ * @file
+ * @brief Defines mathematical constants and functions for both CPU and CUDA execution.
+ * @details This header provides a hardware-agnostic API for common mathematical operations
+ * like logarithms, square roots, and random number generation. It uses preprocessor
+ * directives to select the appropriate implementation (standard C++ or CUDA) at compile time.
+ */
 #ifndef MQI_MATH_HPP
 #define MQI_MATH_HPP
-
-/// \file
-///
-/// A header including CUDA related headers and functions
 
 #include <moqui/base/mqi_common.hpp>
 
@@ -14,109 +17,208 @@
 namespace mqi
 {
 
-//const float near_zero = 0.0000001;
-const float near_zero          = 1e-7;
-const float min_step           = 1e-3;
-const float geometry_tolerance = 1e-3;
+const float near_zero          = 1e-7f;      ///< A small value used to avoid floating-point comparison issues.
+const float min_step           = 1e-3f;      ///< The minimum step size for particle transport.
+const float geometry_tolerance = 1e-3f;      ///< A tolerance value for geometry intersection calculations.
+const float m_inf              = -HUGE_VALF; ///< Negative infinity.
+const float p_inf              = HUGE_VALF;  ///< Positive infinity.
 
-///< TODO: CUDA m_inf
-const float m_inf = -1.0 * HUGE_VALF;
-const float p_inf = HUGE_VALF;
-
+/**
+ * @brief Performs 1D linear interpolation.
+ * @tparam T The floating-point type (e.g., float or double).
+ * @param[in] x The point at which to interpolate.
+ * @param[in] x0 The first x-coordinate.
+ * @param[in] x1 The second x-coordinate.
+ * @param[in] y0 The first y-coordinate, corresponding to x0.
+ * @param[in] y1 The second y-coordinate, corresponding to x1.
+ * @return The interpolated y-value at x.
+ */
 template<typename T>
 CUDA_DEVICE inline T
 intpl1d(T x, T x0, T x1, T y0, T y1) {
     return (x1 == x0) ? y0 : y0 + (x - x0) * (y1 - y0) / (x1 - x0);
 }
 
+/**
+ * @brief Calculates the natural logarithm. Wrapper for `log` or `logf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The natural logarithm of s.
+ */
 template<typename T>
 CUDA_DEVICE T
 mqi_ln(T s);
 
+/**
+ * @brief Calculates the square root. Wrapper for `sqrt` or `sqrtf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The square root of s.
+ */
 template<typename T>
 CUDA_HOST_DEVICE T
 mqi_sqrt(T s);
 
+/**
+ * @brief Calculates a number raised to a power. Wrapper for `pow` or `powf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The base.
+ * @param[in] p The exponent.
+ * @return s raised to the power of p.
+ */
 template<typename T>
 CUDA_DEVICE T
 mqi_pow(T s, T p);
 
+/**
+ * @brief Calculates the base-e exponential. Wrapper for `exp` or `expf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return e raised to the power of s.
+ */
 template<typename T>
 CUDA_DEVICE T
 mqi_exp(T s);
 
+/**
+ * @brief Calculates the arc cosine. Wrapper for `acos` or `acosf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The arc cosine of s.
+ */
 template<typename T>
 CUDA_DEVICE T
 mqi_acos(T s);
 
+/**
+ * @brief Calculates the cosine. Wrapper for `cos` or `cosf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The cosine of s.
+ */
 template<typename T>
 CUDA_DEVICE T
 mqi_cos(T s);
 
+/**
+ * @brief Calculates the sine. Wrapper for `sin` or `sinf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The sine of s.
+ */
 template<typename T>
 CUDA_DEVICE T
 mqi_sin(T s);
 
+/**
+ * @brief Calculates the absolute value. Wrapper for `abs` or `fabs`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The absolute value of s.
+ */
 template<typename T>
 CUDA_DEVICE T
 mqi_abs(T s);
 
+/**
+ * @brief Rounds a number to the nearest integer. Wrapper for `round` or `roundf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The rounded value.
+ */
 template<typename T>
 CUDA_HOST_DEVICE T
 mqi_round(T s);
 
+/**
+ * @brief Calculates the floor of a number. Wrapper for `floor` or `floorf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The floor value.
+ */
 template<typename T>
 CUDA_HOST_DEVICE T
 mqi_floor(T s);
 
+/**
+ * @brief Calculates the ceiling of a number. Wrapper for `ceil` or `ceilf`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return The ceiling value.
+ */
 template<typename T>
 CUDA_HOST_DEVICE T
 mqi_ceil(T s);
 
+/**
+ * @brief Checks if a number is NaN (Not a Number). Wrapper for `isnan`.
+ * @tparam T The floating-point type.
+ * @param[in] s The value.
+ * @return True if s is NaN, false otherwise.
+ */
 template<typename T>
 CUDA_HOST_DEVICE bool
 mqi_isnan(T s);
 
-/*
-template<typename T>
-CUDA_DEVICE
-T mqi_inf();
-*/
-
-///< To make template for both return type and argument.
-///< 1. return type template
+/**
+ * @struct rnd_return
+ * @brief A helper struct to define the return type for random number generators.
+ * @tparam T The desired floating-point type (float or double).
+ */
 template<class T>
 struct rnd_return {
     typedef T type;
 };
 
+/// @brief Specialization for float.
 template<>
 struct rnd_return<float> {
     typedef float type;
 };
 
+/// @brief Specialization for double.
 template<>
 struct rnd_return<double> {
     typedef double type;
 };
 
-///< 2. distribution funtion template.
-
-///< normal
+/**
+ * @brief Generates a normally distributed random number.
+ * @tparam T The floating-point type of the distribution parameters.
+ * @tparam S The type of the random number generator state/engine.
+ * @param[in,out] rng A pointer to the random number generator.
+ * @param[in] avg The mean of the distribution.
+ * @param[in] sig The standard deviation of the distribution.
+ * @return A random number from the specified normal distribution.
+ */
 template<class T, class S>
 CUDA_DEVICE typename rnd_return<T>::type
 mqi_normal(S* rng, T avg, T sig) {
     return T();
 }
 
-///< uniform
+/**
+ * @brief Generates a uniformly distributed random number in [0, 1).
+ * @tparam T The floating-point type of the return value.
+ * @tparam S The type of the random number generator state/engine.
+ * @param[in,out] rng A pointer to the random number generator.
+ * @return A random number from the uniform distribution.
+ */
 template<class T, class S>
 CUDA_DEVICE typename rnd_return<T>::type
 mqi_uniform(S* rng) {
     return T();
 }
 
-///< exponetial distribution
+/**
+ * @brief Generates an exponentially distributed random number.
+ * @tparam T The floating-point type of the distribution parameters.
+ * @tparam S The type of the random number generator state/engine.
+ * @param[in,out] rng A pointer to the random number generator.
+ * @param[in] avg The mean of the distribution (lambda = 1/avg).
+ * @param[in] up The upper bound for the generated random number.
+ * @return A random number from the specified exponential distribution.
+ */
 template<class T, class S>
 CUDA_DEVICE typename rnd_return<T>::type
 mqi_exponential(S* rng, T avg, T up) {

--- a/base/mqi_node.hpp
+++ b/base/mqi_node.hpp
@@ -1,3 +1,7 @@
+/**
+ * @file
+ * @brief Defines the node structure for the geometry hierarchy.
+ */
 #ifndef MQI_NODE_HPP
 #define MQI_NODE_HPP
 
@@ -8,32 +12,32 @@
 #include <cuda_fp16.h>
 #endif
 
-/// navigator needs to have "struct" to store those status
-/// core-parts should be running in parallel manner, MT, CUDA, OpenCL, FPGA?
-/// navigator is shared by block level or device level.
 namespace mqi
 {
 
-///< node_t : a geometry and it's scorers
-/// T: material id
-/// R: values in x/y/z and scoreing type
+/**
+ * @struct node_t
+ * @brief Represents a node in a hierarchical geometry, containing geometry, scorers, and child nodes.
+ * @tparam R The floating-point type for scoring and geometry values (e.g., float or double).
+ * @details This structure is a core component of the simulation geometry, allowing for nested or complex arrangements. Each node can have its own geometry definition and a set of scorers to record data.
+ */
 template<typename R>
 struct node_t {
-    ///< node's geometry
-    grid3d<mqi::density_t, R>* geo = nullptr;
+    grid3d<mqi::density_t, R>* geo = nullptr;   ///< A pointer to the node's geometry, defined as a 3D grid.
 
-    ///< node's scorers
-    /// scorer's data, count, mean, and variance need to be allocated seperately
-    /// and have corresponding host pointers to download from GPU to CPU.
-    uint16_t         n_scorers        = 0;
-    scorer<R>**      scorers          = nullptr;
-    mqi::key_value** scorers_data     = nullptr;
-    mqi::key_value** scorers_count    = nullptr;
-    mqi::key_value** scorers_mean     = nullptr;
-    mqi::key_value** scorers_variance = nullptr;
+    uint16_t         n_scorers = 0;         ///< The number of scorers attached to this node.
+    scorer<R>**      scorers   = nullptr;   ///< An array of pointers to the scorer objects.
+    mqi::key_value** scorers_data =
+        nullptr;   ///< An array of pointers to the primary data for each scorer (e.g., dose).
+    mqi::key_value** scorers_count =
+        nullptr;   ///< An array of pointers to the count data for each scorer (for statistical calculations).
+    mqi::key_value** scorers_mean =
+        nullptr;   ///< An array of pointers to the mean value data for each scorer.
+    mqi::key_value** scorers_variance =
+        nullptr;   ///< An array of pointers to the variance data for each scorer.
 
-    uint16_t           n_children = 0;
-    struct node_t<R>** children   = nullptr;
+    uint16_t           n_children = 0;      ///< The number of child nodes.
+    struct node_t<R>** children   = nullptr;   ///< An array of pointers to the child nodes.
 };
 
 }   // namespace mqi

--- a/base/mqi_physics_constants.hpp
+++ b/base/mqi_physics_constants.hpp
@@ -1,3 +1,7 @@
+/**
+ * @file
+ * @brief Defines a struct containing fundamental physical constants and unit conversions.
+ */
 #ifndef MQI_PHYSICS_CONSTANTS_HPP
 #define MQI_PHYSICS_CONSTANTS_HPP
 
@@ -6,35 +10,41 @@
 namespace mqi
 {
 
-/*
-	Water: RadL = 36.093 cm, Nucl.Int.Lengh = 75.375 cm
-	electromagnetic coupling = 1.43996e-12 MeV*mm/(eplus^2) , eplus  =1 
-	static const double classic_electr_radius  = elm_coupling/electron_mass_c2;
-	*/
+/**
+ * @struct physics_constants
+ * @brief A collection of fundamental physical constants and unit conversions.
+ * @tparam R The floating-point type (e.g., float or double) used for the constants.
+ * @details This struct provides a centralized and consistent source for physical constants
+ * required in the simulation, such as particle masses, lengths, and energy units.
+ */
 template<typename R>
 struct physics_constants {
-    const R mm                     = 1.0;   //default length unit
-    const R cm                     = 10.0;
-    const R cm3                    = cm * cm * cm;
-    const R mm3                    = mm * mm * mm;
-    const R MeV                    = 1.0;
-    const R eV                     = 1e-6;
-    const R Mp                     = 938.272046 * MeV;   // Mp/eV = proton mass in eV
-    const R Mp_sq                  = Mp * Mp;
-    const R Me                     = 0.510998928 * MeV;
-    const R Mo                     = 14903.3460795634 * MeV;
-    const R Mo_sq                  = Mo * Mo;
-    const R MoMp                   = Mo / Mp;
-    const R MoMp_sq                = MoMp * MoMp;
-    const R MeMp                   = Me / Mp;                 // Me/Mp
-    const R MeMp_sq                = MeMp * MeMp;             // (Me/Mp)^2
-    const R re                     = 2.8179403262e-12 * mm;   //classic_electron_radius
-    const R re_sq                  = re * re;
-    const R two_pi_re2_mc2         = 2.0 * M_PI * re_sq * Me;
-    const R two_pi_re2_mc2_h2o     = two_pi_re2_mc2 * 3.3428e+23 / cm3;
-    const R water_density          = 1.0 / cm3;      //1g/mm3
-    const R radiation_length_water = 36.0863 * cm;   //mm 360.863
-    const R mev_to_joule           = 1.60218e-13;    // J/MeV
+    const R mm = 1.0;   ///< Default length unit (millimeter).
+    const R cm = 10.0;  ///< Centimeter in terms of millimeters.
+    const R cm3 =
+        cm * cm * cm;   ///< Cubic centimeter in terms of cubic millimeters.
+    const R mm3   = mm * mm * mm;   ///< Cubic millimeter.
+    const R MeV   = 1.0;            ///< Default energy unit (Mega-electron Volt).
+    const R eV    = 1e-6;           ///< Electron Volt in terms of MeV.
+    const R Mp    = 938.272046 * MeV;   ///< Proton mass in MeV.
+    const R Mp_sq = Mp * Mp;            ///< Square of the proton mass.
+    const R Me    = 0.510998928 * MeV;  ///< Electron mass in MeV.
+    const R Mo    = 14903.3460795634 * MeV;   ///< Oxygen atom mass in MeV.
+    const R Mo_sq = Mo * Mo;                  ///< Square of the oxygen mass.
+    const R MoMp  = Mo / Mp;                  ///< Ratio of Oxygen mass to Proton mass.
+    const R MoMp_sq = MoMp * MoMp;            ///< Square of the Oxygen/Proton mass ratio.
+    const R MeMp = Me / Mp;     ///< Ratio of Electron mass to Proton mass.
+    const R MeMp_sq = MeMp * MeMp;   ///< Square of the Electron/Proton mass ratio.
+    const R re =
+        2.8179403262e-12 * mm;   ///< Classical electron radius in mm.
+    const R re_sq            = re * re;   ///< Square of the classical electron radius.
+    const R two_pi_re2_mc2   = 2.0 * M_PI * re_sq * Me;   ///< A pre-calculated constant: 2 * pi * r_e^2 * m_e * c^2.
+    const R two_pi_re2_mc2_h2o =
+        two_pi_re2_mc2 * 3.3428e+23 / cm3;   ///< The `two_pi_re2_mc2` constant scaled by the electron density of water.
+    const R water_density = 1.0 / cm3;   ///< Density of water (1 g/cm^3) in g/mm^3.
+    const R radiation_length_water =
+        36.0863 * cm;   ///< Radiation length of water in mm.
+    const R mev_to_joule = 1.60218e-13;   ///< Conversion factor from MeV to Joules.
 };
 
 }   // namespace mqi

--- a/base/mqi_physics_list.hpp
+++ b/base/mqi_physics_list.hpp
@@ -1,3 +1,7 @@
+/**
+ * @file
+ * @brief Defines structures and classes for managing physics processes and parameters.
+ */
 #ifndef MQI_PHYSICS_LIST_HPP
 #define MQI_PHYSICS_LIST_HPP
 
@@ -6,35 +10,46 @@
 namespace mqi
 {
 
-///< struct for Minimum step length and process id
-//P-> 0: CSDA, 1: delta_ion, 2: pp-elastic, 3: po-elastic, 4: po-inelastic
-//P-> -1: by geometry
+/**
+ * @struct dL_t
+ * @brief A struct to hold a proposed step length and the ID of the physics process that generated it.
+ * @tparam R The floating-point type for the step length.
+ */
 template<typename R>
 struct dL_t {
-    R      L;
-    int8_t P;
+    R      L;   ///< The proposed step length.
+    int8_t P;   ///< The ID of the physics process. (-1 for geometry boundary). P-> 0: CSDA, 1: delta_ion, 2: pp-elastic, 3: po-elastic, 4: po-inelastic
 };
 
-///<
+/**
+ * @class physics_list
+ * @brief A class to manage physics parameters and settings for the simulation.
+ * @tparam R The floating-point type for energy cuts and step limits.
+ * @details This class holds various energy cutoffs and step size limits that control the behavior of physics interactions.
+ */
 template<typename R>
 class physics_list
 {
 public:
-    const physics_constants<R> units;
-    R       Te_cut   = 0.08511 * units.MeV;   //0.1 will set mpf 0 up to 45 MeV proton
-    const R Tp_cut   = 0.5 * units.MeV;
-    const R Tp_max   = 330.0 * units.MeV;   // maximum proton energy to deal
-    const R Tp_up    = 2.0 * units.MeV;     //restricted stopping power
-    const R max_step = 1.0 * units.cm;
+    const physics_constants<R> units;               ///< A struct holding physical constants and conversion factors.
+    R       Te_cut   = 0.08511 * units.MeV;   ///< Kinetic energy cut for secondary electrons.
+    const R Tp_cut   = 0.5 * units.MeV;         ///< Kinetic energy cut for secondary protons.
+    const R Tp_max   = 330.0 * units.MeV;       ///< Maximum proton energy to be handled by the simulation.
+    const R Tp_up    = 2.0 * units.MeV;         ///< Upper limit for applying restricted stopping power.
+    const R max_step = 1.0 * units.cm;          ///< The absolute maximum allowed step length.
 
-    ///Number of processes per particle
-    ///< photon, electron, proton, neutron
 public:
+    /**
+     * @brief Default constructor.
+     */
     CUDA_HOST_DEVICE
     physics_list() {
         ;
     }
 
+    /**
+     * @brief Destructor.
+     */
     CUDA_HOST_DEVICE
     ~physics_list() {}
 };

--- a/progress.md
+++ b/progress.md
@@ -41,3 +41,14 @@ The following files have been fully documented with Doxygen-style docstrings:
 33. `base/mqi_fippel_physics.hpp`
 34. `base/mqi_geometry.hpp`
 35. `base/mqi_grid3d.hpp`
+36. `base/mqi_hash_table.hpp`
+37. `base/mqi_interaction.hpp`
+38. `base/mqi_io.hpp`
+39. `base/mqi_material.hpp`
+40. `base/mqi_math.hpp`
+41. `base/mqi_matrix.hpp`
+42. `base/mqi_node.hpp`
+43. `base/mqi_p_ionization.hpp`
+44. `base/mqi_physics_constants.hpp`
+45. `base/mqi_physics_list.hpp`
+46. `base/mqi_po_elastic.hpp`


### PR DESCRIPTION
This commit adds comprehensive Doxygen-style documentation to the second group of files as specified in `todolist.txt`.

The following files have been documented:
- `base/mqi_hash_table.hpp`
- `base/mqi_interaction.hpp`
- `base/mqi_io.hpp`
- `base/mqi_material.hpp`
- `base/mqi_math.hpp`
- `base/mqi_matrix.hpp`
- `base/mqi_node.hpp`
- `base/mqi_p_ionization.hpp`
- `base/mqi_physics_constants.hpp`
- `base/mqi_physics_list.hpp`
- `base/mqi_po_elastic.hpp`

The `progress.md` file has been updated to reflect these changes. The `README.md` file has been updated with a note for AI agents.