### PR TITLE
feat: Implement Phase 2 particle sorting by energy

### DIFF
--- a/base/environments/mqi_tps_env.hpp
+++ b/base/environments/mqi_tps_env.hpp
@@ -39,6 +39,11 @@
 #include <moqui/base/scorers/mqi_scorer_energy_deposit.hpp>
 #include <valarray>
 
+#if defined(__CUDACC__)
+#include <thrust/sort.h>
+#include <thrust/device_ptr.h>
+#endif
+
 namespace mqi
 {
 /// \struct dicom_t
@@ -1248,6 +1253,20 @@ public:
         mc::upload_vertices(this->vertices, mc::mc_vertices, 0, histories_per_batch);
         cudaDeviceSynchronize();
         check_cuda_last_error("(upload vertices)");
+
+        // Sort particles by energy to improve memory access patterns and reduce thread divergence
+        printf("Sorting %lu particles by energy...\n", histories_in_batch);
+        try {
+            thrust::device_ptr<mqi::vertex_t<R>> d_vertices_ptr(mc::mc_vertices);
+            thrust::sort(thrust::device, d_vertices_ptr, d_vertices_ptr + histories_in_batch, mqi::by_energy_vtx<R>());
+            cudaDeviceSynchronize();
+            check_cuda_last_error("(thrust::sort)");
+            printf("Particle sorting complete.\n");
+        } catch (const thrust::system_error& e) {
+            fprintf(stderr, "Thrust sort failed: %s\n", e.what());
+            // Decide how to handle the error, maybe exit or continue without sorting
+        }
+
         uint32_t* d_scorer_offset_vector;
         if (scorer_offset_vector) {
             printf("Printing simulation specification.. : Histories per batch --> %d\n", histories_per_batch);

--- a/base/mqi_vertex.hpp
+++ b/base/mqi_vertex.hpp
@@ -34,5 +34,22 @@ struct vertex_t {
     }
 };
 
+/// @brief Functor to compare two vertices by kinetic energy in descending order for sorting.
+/// @tparam R The floating-point type for kinetic energy.
+template<typename R>
+struct by_energy_vtx
+{
+    /// @brief Overloaded operator to perform the comparison.
+    /// @param a The first vertex.
+    /// @param b The second vertex.
+    /// @return `true` if vertex `a` has higher or equal kinetic energy than vertex `b`.
+    __host__ __device__ bool
+    operator()(const vertex_t<R>& a, const vertex_t<R>& b)
+    {
+        // Sorts in descending order of kinetic energy
+        return a.ke > b.ke;
+    }
+};
+
 }   // namespace mqi
 #endif


### PR DESCRIPTION
This commit introduces particle sorting based on kinetic energy, as outlined in Phase 2 of the performance improvement plan. This is intended to improve GPU cache performance and reduce thread divergence during the particle transport step.

The key changes include:
- A new sorting functor, `by_energy_vtx`, has been added to `mqi_vertex.hpp` to compare two `vertex_t` objects by their kinetic energy.
- The `run_simulation` function in `mqi_tps_env.hpp` now uses `thrust::sort` to reorder the `mc::mc_vertices` array on the GPU before launching the transport kernel.

This implementation adapts the original plan, which incorrectly referenced sorting `track_t` objects. The sorting is now correctly applied to the persistent `vertex_t` data structure.