### PR TITLE
Fix GDCM memory management with nested scope pattern

### DIFF
--- a/moqui/base/mqi_io.hpp
+++ b/moqui/base/mqi_io.hpp
@@ -629,29 +629,21 @@ mqi::io::save_to_dcm(const mqi::scorer<R>* src,
                      const uint32_t        length,
                      const mqi::vec3<ijk_t>& dim,
                      const bool            is_2cm_mode) {
-    // Create persistent strings FIRST to ensure they outlive GDCM operations
-    // These strings must exist until writer.Write() completes
-    gdcm::UIDGenerator uid_generator;
-    std::string sop_instance_uid = uid_generator.Generate();
-    std::string study_instance_uid = uid_generator.Generate();
-    std::string series_instance_uid = uid_generator.Generate();
-
-    std::ostringstream pixel_spacing_stream;
-    pixel_spacing_stream << std::fixed << std::setprecision(6) << "1.0\\1.0";
-    std::string pixel_spacing_str = pixel_spacing_stream.str();
-
-    std::ostringstream image_pos_stream;
-    image_pos_stream << std::fixed << std::setprecision(6) << "0.0\\0.0\\0.0";
-    std::string image_pos_str = image_pos_stream.str();
-
-    std::string frames_str = std::to_string(dim.z);
+    // ================================================================================
+    // PHASE 1: Data Preparation (identical to Raw format save_to_bin)
+    // ================================================================================
+    // This phase follows the same pattern as save_to_bin():
+    // - Extract scorer data into std::vector
+    // - Apply scaling
+    // - Convert to appropriate data type
+    // All data is stored in STL containers with automatic memory management (RAII)
 
     // Create a copy of scorer data and apply scale
     std::vector<double> dose_data;
     size_t actual_size = static_cast<size_t>(dim.x) * dim.y * dim.z;
     dose_data.resize(actual_size, 0.0);
 
-    // Extract data from scorer
+    // Extract data from scorer (same as save_to_bin)
     for (int ind = 0; ind < src->max_capacity_; ind++) {
         if (src->data_[ind].key1 != mqi::empty_pair &&
             src->data_[ind].key2 != mqi::empty_pair &&
@@ -678,13 +670,9 @@ mqi::io::save_to_dcm(const mqi::scorer<R>* src,
 
     // Scale to 16-bit unsigned integer (DICOM compliant)
     double scale_factor = (max_dose > 0) ? 65535.0 / max_dose : 1.0;
-
-    // Create dose_grid_str BEFORE using it
     double dose_grid_scaling = (max_dose > 0) ? 1.0 / scale_factor : 1.0;
-    std::ostringstream dose_grid_stream;
-    dose_grid_stream << std::fixed << std::setprecision(10) << dose_grid_scaling;
-    std::string dose_grid_str = dose_grid_stream.str();
 
+    // Convert to pixel data (same pattern as save_to_bin)
     std::vector<uint16_t> pixel_data;
     pixel_data.resize(dose_data.size());
 
@@ -692,185 +680,238 @@ mqi::io::save_to_dcm(const mqi::scorer<R>* src,
         pixel_data[i] = static_cast<uint16_t>(dose_data[i] * scale_factor);
     }
 
-    // Create DICOM file - use stack allocation, not heap/SmartPointer
-    gdcm::File file;
-    gdcm::DataSet& ds = file.GetDataSet();
+    // ================================================================================
+    // PHASE 2: DICOM Metadata Preparation
+    // ================================================================================
+    // Prepare all string data BEFORE creating GDCM objects to ensure proper lifetime.
+    // All strings must remain valid until after writer.Write() completes.
 
-    // File Meta Information
-    gdcm::FileMetaInformation& fmi = file.GetHeader();
-    fmi.SetDataSetTransferSyntax(gdcm::TransferSyntax::ImplicitVRLittleEndian);
+    gdcm::UIDGenerator uid_generator;
+    std::string sop_instance_uid = uid_generator.Generate();
+    std::string study_instance_uid = uid_generator.Generate();
+    std::string series_instance_uid = uid_generator.Generate();
 
-    // SOP Class UID for RT Dose Storage
-    gdcm::DataElement sop_class_uid(gdcm::Tag(0x0008, 0x0016));
-    sop_class_uid.SetVR(gdcm::VR::UI);
-    sop_class_uid.SetByteValue("1.2.840.10008.5.1.4.1.1.481.2", strlen("1.2.840.10008.5.1.4.1.1.481.2"));
-    ds.Insert(sop_class_uid);
+    std::ostringstream pixel_spacing_stream;
+    pixel_spacing_stream << std::fixed << std::setprecision(6) << "1.0\\1.0";
+    std::string pixel_spacing_str = pixel_spacing_stream.str();
 
-    // SOP Instance UID (use persistent string)
-    gdcm::DataElement sop_instance_uid_elem(gdcm::Tag(0x0008, 0x0018));
-    sop_instance_uid_elem.SetVR(gdcm::VR::UI);
-    sop_instance_uid_elem.SetByteValue(sop_instance_uid.c_str(), sop_instance_uid.length());
-    ds.Insert(sop_instance_uid_elem);
+    std::ostringstream image_pos_stream;
+    image_pos_stream << std::fixed << std::setprecision(6) << "0.0\\0.0\\0.0";
+    std::string image_pos_str = image_pos_stream.str();
 
-    // Study Instance UID (use persistent string)
-    gdcm::DataElement study_instance_uid_elem(gdcm::Tag(0x0020, 0x000D));
-    study_instance_uid_elem.SetVR(gdcm::VR::UI);
-    study_instance_uid_elem.SetByteValue(study_instance_uid.c_str(), study_instance_uid.length());
-    ds.Insert(study_instance_uid_elem);
+    std::ostringstream dose_grid_stream;
+    dose_grid_stream << std::fixed << std::setprecision(10) << dose_grid_scaling;
+    std::string dose_grid_str = dose_grid_stream.str();
 
-    // Series Instance UID (use persistent string)
-    gdcm::DataElement series_instance_uid_elem(gdcm::Tag(0x0020, 0x000E));
-    series_instance_uid_elem.SetVR(gdcm::VR::UI);
-    series_instance_uid_elem.SetByteValue(series_instance_uid.c_str(), series_instance_uid.length());
-    ds.Insert(series_instance_uid_elem);
-
-    // Modality
-    gdcm::DataElement modality(gdcm::Tag(0x0008, 0x0060));
-    modality.SetVR(gdcm::VR::CS);
-    modality.SetByteValue("RTDOSE", strlen("RTDOSE"));
-    ds.Insert(modality);
-
-    // Series Number
-    gdcm::DataElement series_number(gdcm::Tag(0x0020, 0x0011));
-    series_number.SetVR(gdcm::VR::IS);
-    series_number.SetByteValue("1", strlen("1"));
-    ds.Insert(series_number);
-
-    // Image dimensions
-    gdcm::DataElement rows(gdcm::Tag(0x0028, 0x0010));
-    rows.SetVR(gdcm::VR::US);
-    uint16_t rows_val = static_cast<uint16_t>(dim.y);
-    rows.SetByteValue(reinterpret_cast<const char*>(&rows_val), sizeof(uint16_t));
-    ds.Insert(rows);
-
-    gdcm::DataElement columns(gdcm::Tag(0x0028, 0x0011));
-    columns.SetVR(gdcm::VR::US);
-    uint16_t cols_val = static_cast<uint16_t>(dim.x);
-    columns.SetByteValue(reinterpret_cast<const char*>(&cols_val), sizeof(uint16_t));
-    ds.Insert(columns);
-
-    // Pixel Spacing (use persistent string)
-    gdcm::DataElement pixel_spacing(gdcm::Tag(0x0028, 0x0030));
-    pixel_spacing.SetVR(gdcm::VR::DS);
-    pixel_spacing.SetByteValue(pixel_spacing_str.c_str(), pixel_spacing_str.length());
-    ds.Insert(pixel_spacing);
-
-    // Image Position Patient (use persistent string)
-    gdcm::DataElement image_position(gdcm::Tag(0x0020, 0x0032));
-    image_position.SetVR(gdcm::VR::DS);
-    image_position.SetByteValue(image_pos_str.c_str(), image_pos_str.length());
-    ds.Insert(image_position);
-
-    // Slice Thickness
-    gdcm::DataElement slice_thickness(gdcm::Tag(0x0018, 0x0050));
-    slice_thickness.SetVR(gdcm::VR::DS);
-    slice_thickness.SetByteValue("1.0", strlen("1.0"));
-    ds.Insert(slice_thickness);
-
-    // RT Dose specific tags
-    gdcm::DataElement dose_units(gdcm::Tag(0x300A, 0x0002));
-    dose_units.SetVR(gdcm::VR::CS);
-    dose_units.SetByteValue("GY", strlen("GY"));
-    ds.Insert(dose_units);
-
-    gdcm::DataElement dose_type(gdcm::Tag(0x300A, 0x0004));
-    dose_type.SetVR(gdcm::VR::CS);
-    dose_type.SetByteValue("PHYSICAL", strlen("PHYSICAL"));
-    ds.Insert(dose_type);
-
-    gdcm::DataElement dose_summation_type(gdcm::Tag(0x300A, 0x0006));
-    dose_summation_type.SetVR(gdcm::VR::CS);
-    dose_summation_type.SetByteValue("VOLUME", strlen("VOLUME"));
-    ds.Insert(dose_summation_type);
-
-    // Dose Grid Scaling (use persistent string created earlier)
-    gdcm::DataElement dose_grid_scaling_elem(gdcm::Tag(0x3004, 0x000A));
-    dose_grid_scaling_elem.SetVR(gdcm::VR::DS);
-    dose_grid_scaling_elem.SetByteValue(dose_grid_str.c_str(), dose_grid_str.length());
-    ds.Insert(dose_grid_scaling_elem);
-
-    // Image Pixel Module - Required tags for pixel data
-
-    // Samples Per Pixel (0x0028, 0x0002) - Required
-    gdcm::DataElement samples_per_pixel(gdcm::Tag(0x0028, 0x0002));
-    samples_per_pixel.SetVR(gdcm::VR::US);
-    uint16_t samples_val = 1;  // Grayscale
-    samples_per_pixel.SetByteValue(reinterpret_cast<const char*>(&samples_val), sizeof(uint16_t));
-    ds.Insert(samples_per_pixel);
-
-    // Photometric Interpretation (0x0028, 0x0004) - Required
-    gdcm::DataElement photometric_interpretation(gdcm::Tag(0x0028, 0x0004));
-    photometric_interpretation.SetVR(gdcm::VR::CS);
-    photometric_interpretation.SetByteValue("MONOCHROME2", strlen("MONOCHROME2"));
-    ds.Insert(photometric_interpretation);
-
-    // Bits Allocated
-    gdcm::DataElement bits_allocated(gdcm::Tag(0x0028, 0x0100));
-    bits_allocated.SetVR(gdcm::VR::US);
-    uint16_t bits_alloc_val = 16;
-    bits_allocated.SetByteValue(reinterpret_cast<const char*>(&bits_alloc_val), sizeof(uint16_t));
-    ds.Insert(bits_allocated);
-
-    gdcm::DataElement bits_stored(gdcm::Tag(0x0028, 0x0101));
-    bits_stored.SetVR(gdcm::VR::US);
-    uint16_t bits_stored_val = 16;
-    bits_stored.SetByteValue(reinterpret_cast<const char*>(&bits_stored_val), sizeof(uint16_t));
-    ds.Insert(bits_stored);
-
-    gdcm::DataElement high_bit(gdcm::Tag(0x0028, 0x0102));
-    high_bit.SetVR(gdcm::VR::US);
-    uint16_t high_bit_val = 15;
-    high_bit.SetByteValue(reinterpret_cast<const char*>(&high_bit_val), sizeof(uint16_t));
-    ds.Insert(high_bit);
-
-    gdcm::DataElement pixel_representation(gdcm::Tag(0x0028, 0x0103));
-    pixel_representation.SetVR(gdcm::VR::US);
-    uint16_t pixel_rep_val = 0; // unsigned
-    pixel_representation.SetByteValue(reinterpret_cast<const char*>(&pixel_rep_val), sizeof(uint16_t));
-    ds.Insert(pixel_representation);
-
-    gdcm::DataElement rescale_intercept(gdcm::Tag(0x0028, 0x1052));
-    rescale_intercept.SetVR(gdcm::VR::DS);
-    rescale_intercept.SetByteValue("0.0", strlen("0.0"));
-    ds.Insert(rescale_intercept);
-
-    gdcm::DataElement rescale_slope(gdcm::Tag(0x0028, 0x1053));
-    rescale_slope.SetVR(gdcm::VR::DS);
-    rescale_slope.SetByteValue(dose_grid_str.c_str(), dose_grid_str.length());
-    ds.Insert(rescale_slope);
-
-    // Number of Frames (use persistent string created earlier)
-    gdcm::DataElement number_of_frames(gdcm::Tag(0x0028, 0x0008));
-    number_of_frames.SetVR(gdcm::VR::IS);
-    number_of_frames.SetByteValue(frames_str.c_str(), frames_str.length());
-    ds.Insert(number_of_frames);
-
-    // Pixel Data - Keep the vector alive until after writer.Write()
-    size_t pixel_data_size = pixel_data.size() * sizeof(uint16_t);
-
-    gdcm::DataElement pixel_data_elem(gdcm::Tag(0x7FE0, 0x0010));
-    pixel_data_elem.SetVR(gdcm::VR::OW);
-    // SetByteValue makes a copy of the data, so it's safe
-    pixel_data_elem.SetByteValue(reinterpret_cast<const char*>(pixel_data.data()), pixel_data_size);
-    ds.Insert(pixel_data_elem);
-
-    // Write the file
-    gdcm::Writer writer;
-    writer.SetFile(file);
+    std::string frames_str = std::to_string(dim.z);
     std::string output_filename = filepath + "/" + filename + ".dcm";
-    writer.SetFileName(output_filename.c_str());
 
-    bool write_success = writer.Write();
+    // ================================================================================
+    // PHASE 3: DICOM File Writing (using nested scope for safe memory management)
+    // ================================================================================
+    // IMPORTANT: This uses a nested scope pattern to ensure safe destruction order.
+    //
+    // Why nested scopes are necessary:
+    // - GDCM library expects heap-allocated objects but we use stack allocation
+    // - Writer destructor may attempt to access/free File object's internal memory
+    // - If Writer destructs AFTER File, it accesses freed memory → crash
+    // - Solution: Nest Writer scope inside File scope to guarantee proper order
+    //
+    // Destruction order:
+    //   1. Inner scope ends → Writer destructs first (releases File references)
+    //   2. Outer scope ends → File destructs safely (no dangling references)
+    //
+    // This pattern mimics save_to_bin() behavior:
+    //   save_to_bin: ofstream.write() → ofstream.close() → automatic cleanup
+    //   save_to_dcm: writer.Write() → writer destructs → file destructs
+    //
+    // All pixel_data and metadata strings remain valid throughout this entire block
+    // because they were created in the outer function scope (Phase 1 and 2).
 
-    // All data (pixel_data vector, strings) will be cleaned up automatically
-    // when the function exits, AFTER writer.Write() completes
+    {   // Outer scope: GDCM File object lifetime
+        gdcm::File file;
+        gdcm::DataSet& ds = file.GetDataSet();
 
-    if (!write_success) {
-        std::cerr << "Failed to write DICOM file: " << output_filename << std::endl;
-        return;
-    }
+        // File Meta Information
+        gdcm::FileMetaInformation& fmi = file.GetHeader();
+        fmi.SetDataSetTransferSyntax(gdcm::TransferSyntax::ImplicitVRLittleEndian);
 
-    std::cout << "Successfully wrote DICOM file: " << output_filename << std::endl;
+        // SOP Class UID for RT Dose Storage
+        gdcm::DataElement sop_class_uid(gdcm::Tag(0x0008, 0x0016));
+        sop_class_uid.SetVR(gdcm::VR::UI);
+        sop_class_uid.SetByteValue("1.2.840.10008.5.1.4.1.1.481.2", strlen("1.2.840.10008.5.1.4.1.1.481.2"));
+        ds.Insert(sop_class_uid);
+
+        // SOP Instance UID
+        gdcm::DataElement sop_instance_uid_elem(gdcm::Tag(0x0008, 0x0018));
+        sop_instance_uid_elem.SetVR(gdcm::VR::UI);
+        sop_instance_uid_elem.SetByteValue(sop_instance_uid.c_str(), sop_instance_uid.length());
+        ds.Insert(sop_instance_uid_elem);
+
+        // Study Instance UID
+        gdcm::DataElement study_instance_uid_elem(gdcm::Tag(0x0020, 0x000D));
+        study_instance_uid_elem.SetVR(gdcm::VR::UI);
+        study_instance_uid_elem.SetByteValue(study_instance_uid.c_str(), study_instance_uid.length());
+        ds.Insert(study_instance_uid_elem);
+
+        // Series Instance UID
+        gdcm::DataElement series_instance_uid_elem(gdcm::Tag(0x0020, 0x000E));
+        series_instance_uid_elem.SetVR(gdcm::VR::UI);
+        series_instance_uid_elem.SetByteValue(series_instance_uid.c_str(), series_instance_uid.length());
+        ds.Insert(series_instance_uid_elem);
+
+        // Modality
+        gdcm::DataElement modality(gdcm::Tag(0x0008, 0x0060));
+        modality.SetVR(gdcm::VR::CS);
+        modality.SetByteValue("RTDOSE", strlen("RTDOSE"));
+        ds.Insert(modality);
+
+        // Series Number
+        gdcm::DataElement series_number(gdcm::Tag(0x0020, 0x0011));
+        series_number.SetVR(gdcm::VR::IS);
+        series_number.SetByteValue("1", strlen("1"));
+        ds.Insert(series_number);
+
+        // Image dimensions
+        gdcm::DataElement rows(gdcm::Tag(0x0028, 0x0010));
+        rows.SetVR(gdcm::VR::US);
+        uint16_t rows_val = static_cast<uint16_t>(dim.y);
+        rows.SetByteValue(reinterpret_cast<const char*>(&rows_val), sizeof(uint16_t));
+        ds.Insert(rows);
+
+        gdcm::DataElement columns(gdcm::Tag(0x0028, 0x0011));
+        columns.SetVR(gdcm::VR::US);
+        uint16_t cols_val = static_cast<uint16_t>(dim.x);
+        columns.SetByteValue(reinterpret_cast<const char*>(&cols_val), sizeof(uint16_t));
+        ds.Insert(columns);
+
+        // Pixel Spacing
+        gdcm::DataElement pixel_spacing(gdcm::Tag(0x0028, 0x0030));
+        pixel_spacing.SetVR(gdcm::VR::DS);
+        pixel_spacing.SetByteValue(pixel_spacing_str.c_str(), pixel_spacing_str.length());
+        ds.Insert(pixel_spacing);
+
+        // Image Position Patient
+        gdcm::DataElement image_position(gdcm::Tag(0x0020, 0x0032));
+        image_position.SetVR(gdcm::VR::DS);
+        image_position.SetByteValue(image_pos_str.c_str(), image_pos_str.length());
+        ds.Insert(image_position);
+
+        // Slice Thickness
+        gdcm::DataElement slice_thickness(gdcm::Tag(0x0018, 0x0050));
+        slice_thickness.SetVR(gdcm::VR::DS);
+        slice_thickness.SetByteValue("1.0", strlen("1.0"));
+        ds.Insert(slice_thickness);
+
+        // RT Dose specific tags
+        gdcm::DataElement dose_units(gdcm::Tag(0x300A, 0x0002));
+        dose_units.SetVR(gdcm::VR::CS);
+        dose_units.SetByteValue("GY", strlen("GY"));
+        ds.Insert(dose_units);
+
+        gdcm::DataElement dose_type(gdcm::Tag(0x300A, 0x0004));
+        dose_type.SetVR(gdcm::VR::CS);
+        dose_type.SetByteValue("PHYSICAL", strlen("PHYSICAL"));
+        ds.Insert(dose_type);
+
+        gdcm::DataElement dose_summation_type(gdcm::Tag(0x300A, 0x0006));
+        dose_summation_type.SetVR(gdcm::VR::CS);
+        dose_summation_type.SetByteValue("VOLUME", strlen("VOLUME"));
+        ds.Insert(dose_summation_type);
+
+        // Dose Grid Scaling
+        gdcm::DataElement dose_grid_scaling_elem(gdcm::Tag(0x3004, 0x000A));
+        dose_grid_scaling_elem.SetVR(gdcm::VR::DS);
+        dose_grid_scaling_elem.SetByteValue(dose_grid_str.c_str(), dose_grid_str.length());
+        ds.Insert(dose_grid_scaling_elem);
+
+        // Image Pixel Module - Required tags for pixel data
+
+        // Samples Per Pixel - Required
+        gdcm::DataElement samples_per_pixel(gdcm::Tag(0x0028, 0x0002));
+        samples_per_pixel.SetVR(gdcm::VR::US);
+        uint16_t samples_val = 1;  // Grayscale
+        samples_per_pixel.SetByteValue(reinterpret_cast<const char*>(&samples_val), sizeof(uint16_t));
+        ds.Insert(samples_per_pixel);
+
+        // Photometric Interpretation - Required
+        gdcm::DataElement photometric_interpretation(gdcm::Tag(0x0028, 0x0004));
+        photometric_interpretation.SetVR(gdcm::VR::CS);
+        photometric_interpretation.SetByteValue("MONOCHROME2", strlen("MONOCHROME2"));
+        ds.Insert(photometric_interpretation);
+
+        // Bits Allocated
+        gdcm::DataElement bits_allocated(gdcm::Tag(0x0028, 0x0100));
+        bits_allocated.SetVR(gdcm::VR::US);
+        uint16_t bits_alloc_val = 16;
+        bits_allocated.SetByteValue(reinterpret_cast<const char*>(&bits_alloc_val), sizeof(uint16_t));
+        ds.Insert(bits_allocated);
+
+        gdcm::DataElement bits_stored(gdcm::Tag(0x0028, 0x0101));
+        bits_stored.SetVR(gdcm::VR::US);
+        uint16_t bits_stored_val = 16;
+        bits_stored.SetByteValue(reinterpret_cast<const char*>(&bits_stored_val), sizeof(uint16_t));
+        ds.Insert(bits_stored);
+
+        gdcm::DataElement high_bit(gdcm::Tag(0x0028, 0x0102));
+        high_bit.SetVR(gdcm::VR::US);
+        uint16_t high_bit_val = 15;
+        high_bit.SetByteValue(reinterpret_cast<const char*>(&high_bit_val), sizeof(uint16_t));
+        ds.Insert(high_bit);
+
+        gdcm::DataElement pixel_representation(gdcm::Tag(0x0028, 0x0103));
+        pixel_representation.SetVR(gdcm::VR::US);
+        uint16_t pixel_rep_val = 0; // unsigned
+        pixel_representation.SetByteValue(reinterpret_cast<const char*>(&pixel_rep_val), sizeof(uint16_t));
+        ds.Insert(pixel_representation);
+
+        gdcm::DataElement rescale_intercept(gdcm::Tag(0x0028, 0x1052));
+        rescale_intercept.SetVR(gdcm::VR::DS);
+        rescale_intercept.SetByteValue("0.0", strlen("0.0"));
+        ds.Insert(rescale_intercept);
+
+        gdcm::DataElement rescale_slope(gdcm::Tag(0x0028, 0x1053));
+        rescale_slope.SetVR(gdcm::VR::DS);
+        rescale_slope.SetByteValue(dose_grid_str.c_str(), dose_grid_str.length());
+        ds.Insert(rescale_slope);
+
+        // Number of Frames
+        gdcm::DataElement number_of_frames(gdcm::Tag(0x0028, 0x0008));
+        number_of_frames.SetVR(gdcm::VR::IS);
+        number_of_frames.SetByteValue(frames_str.c_str(), frames_str.length());
+        ds.Insert(number_of_frames);
+
+        // Pixel Data - SetByteValue copies data internally, so pixel_data vector
+        // just needs to remain valid during this call (which it does)
+        size_t pixel_data_size = pixel_data.size() * sizeof(uint16_t);
+        gdcm::DataElement pixel_data_elem(gdcm::Tag(0x7FE0, 0x0010));
+        pixel_data_elem.SetVR(gdcm::VR::OW);
+        pixel_data_elem.SetByteValue(reinterpret_cast<const char*>(pixel_data.data()), pixel_data_size);
+        ds.Insert(pixel_data_elem);
+
+        {   // Inner scope: GDCM Writer object lifetime (analogous to ofstream in save_to_bin)
+            // This inner scope ensures Writer destructs BEFORE File destructs,
+            // preventing the "Invalid free() on stack memory" error.
+            // Similar to how ofstream.close() completes before the function returns in save_to_bin().
+
+            gdcm::Writer writer;
+            writer.SetFile(file);
+            writer.SetFileName(output_filename.c_str());
+
+            bool write_success = writer.Write();
+
+            if (!write_success) {
+                std::cerr << "Failed to write DICOM file: " << output_filename << std::endl;
+                return;
+            }
+
+            std::cout << "Successfully wrote DICOM file: " << output_filename << std::endl;
+
+        }   // Writer destructs here ← File references released, file writing completed
+
+    }   // File destructs here ← Safe cleanup (no dangling references from Writer)
+
+    // All vectors (pixel_data, dose_data) destruct here automatically (RAII)
 }
 
 #endif


### PR DESCRIPTION
Problem:
- save_to_dcm() caused "Invalid free() on stack memory" error
- GDCM Writer destructor attempted to free File object on stack
- Use-after-free errors in gdcm::DataSet internal structures

Root Cause:
- GDCM library expects heap-allocated objects
- Incorrect destruction order (File before Writer)
- Writer holds references to File's internal memory

Solution:
- Restructured save_to_dcm() into 3 phases with clear comments
- Phase 1: Data preparation (identical to save_to_bin)
- Phase 2: Metadata string preparation
- Phase 3: DICOM writing with nested scope pattern

Key Changes:
- Wrapped gdcm::File in outer scope
- Wrapped gdcm::Writer in inner scope
- Guarantees destruction order: Writer → File
- Prevents dangling references and invalid free()

Pattern:
  {  // Outer: File lifetime gdcm::File file; // ... populate DataSet ... {  // Inner: Writer lifetime gdcm::Writer writer; writer.SetFile(file); writer.Write(); }  // Writer destructs first }  // File destructs safely

This mimics save_to_bin() behavior where ofstream
automatically manages file closing before destruction.