### PR TITLE
Add comprehensive DICOM save memory test suite

### DIFF
--- a/DCM_MEMORY_TEST_README.md
+++ b/DCM_MEMORY_TEST_README.md
@@ -1,0 +1,362 @@
+# DICOM Memory Test - README
+
+이 테스트 코드는 `mqi::io::save_to_dcm` 함수의 메모리 관리 문제를 진단하기 위해 설계되었습니다.
+
+## 📋 파일 구성
+
+```
+MOQUI_JKH/
+├── test_dcm_memory.cpp           # 메인 테스트 코드
+├── Makefile.test_dcm             # 빌드 설정
+├── run_dcm_memory_test.sh        # 자동화된 테스트 스크립트
+└── DCM_MEMORY_TEST_README.md     # 이 문서
+```
+
+## 🎯 테스트 목적
+
+1. **메모리 누수 감지**: save_to_dcm 함수 호출 후 메모리가 제대로 해제되는지 확인
+2. **메모리 corruption 감지**: "free(): invalid size" 등의 메모리 오류 재현
+3. **반복 호출 안정성**: 여러 번 호출 시에도 문제없이 동작하는지 확인
+4. **다양한 데이터 크기**: 작은 데이터부터 큰 데이터까지 테스트
+
+## 🚀 빠른 시작
+
+### 방법 1: 자동화 스크립트 사용 (권장)
+
+```bash
+# 모든 테스트 실행
+./run_dcm_memory_test.sh
+
+# 특정 테스트만 실행
+./run_dcm_memory_test.sh basic      # 기본 실행
+./run_dcm_memory_test.sh valgrind   # Valgrind 메모리 체크
+./run_dcm_memory_test.sh asan       # AddressSanitizer
+./run_dcm_memory_test.sh stress     # 스트레스 테스트
+```
+
+### 방법 2: 수동 빌드 및 실행
+
+```bash
+# 1. 빌드
+make -f Makefile.test_dcm
+
+# 2. 실행
+./test_dcm_memory              # 기본 실행 (50회 반복)
+./test_dcm_memory 100          # 100회 반복
+
+# 3. Valgrind로 메모리 체크
+valgrind --leak-check=full --show-leak-kinds=all ./test_dcm_memory
+
+# 4. AddressSanitizer로 빌드 및 실행
+make -f Makefile.test_dcm asan
+ASAN_OPTIONS=detect_leaks=1 ./test_dcm_memory
+```
+
+## 🔍 테스트 모드 상세
+
+### 1. Basic Test (기본 테스트)
+```bash
+./run_dcm_memory_test.sh basic 50
+```
+- 다양한 크기의 데이터로 DICOM 파일 저장
+- 반복 호출을 통한 기본적인 안정성 확인
+- 메모리 사용량 모니터링
+
+### 2. Valgrind Test (메모리 누수 탐지)
+```bash
+./run_dcm_memory_test.sh valgrind 30
+```
+- 메모리 누수 및 잘못된 메모리 접근 탐지
+- 상세한 메모리 오류 리포트 생성
+- 결과: `test_reports/valgrind_report.txt`
+
+**확인 항목:**
+- `definitely lost`: 확실한 메모리 누수
+- `indirectly lost`: 간접적 메모리 누수
+- `invalid read/write`: 잘못된 메모리 접근
+- `ERROR SUMMARY`: 전체 오류 요약
+
+### 3. AddressSanitizer Test (메모리 오류 탐지)
+```bash
+./run_dcm_memory_test.sh asan 30
+```
+- 런타임 메모리 오류 탐지 (버퍼 오버플로우, use-after-free 등)
+- Valgrind보다 빠른 실행 속도
+- 결과: `test_reports/asan_report.*`
+
+**탐지 가능한 오류:**
+- Heap buffer overflow
+- Use after free
+- Double free
+- Memory leak
+- Invalid pointer dereference
+
+### 4. Stress Test (스트레스 테스트)
+```bash
+./run_dcm_memory_test.sh stress 1000
+```
+- 많은 반복 호출로 간헐적 메모리 문제 재현
+- 장시간 실행 안정성 확인
+
+## 📊 테스트 결과 해석
+
+### 성공적인 실행
+```
+✓ All tests passed!
+VmSize: ~100 MB (안정적 유지)
+VmRSS: ~50 MB (안정적 유지)
+```
+
+### 메모리 누수 발견
+```
+Valgrind:
+  definitely lost: 1,024 bytes in 1 blocks
+
+ASAN:
+  Direct leak of 1024 byte(s) in 1 object(s)
+```
+
+### 메모리 corruption 발견
+```
+free(): invalid size
+*** stack smashing detected ***
+AddressSanitizer: heap-buffer-overflow
+```
+
+## 🐛 알려진 문제 및 해결 방법
+
+### 문제 1: "free(): invalid size" 오류
+
+**원인:**
+- GDCM의 DataElement::SetByteValue()가 포인터만 저장
+- std::vector 소멸 시 GDCM이 해제 시도 → allocator mismatch
+
+**해결 방법:**
+- gdcm::Image::SetBuffer() 사용 (데이터 복사)
+- 또는 GDCM이 관리할 수 있는 메모리 할당 사용
+
+**현재 코드 상태:**
+- mqi_io.hpp의 save_to_dcm 함수는 Image API를 사용하도록 수정됨 (라인 745-905)
+- 하지만 GDCM 3.0에서는 SetBuffer() API가 제거되어 직접 DataElement 설정 필요
+
+### 문제 2: 메모리 누수
+
+**확인 방법:**
+```bash
+# 반복 실행하면서 메모리 증가 확인
+watch -n 1 'ps aux | grep test_dcm_memory | grep -v grep'
+
+# 또는 테스트 내부 출력 확인
+./test_dcm_memory 100
+# VmRSS가 계속 증가하면 메모리 누수
+```
+
+### 문제 3: GDCM SmartPointer 사용
+
+**현재 코드 (라인 765-767):**
+```cpp
+gdcm::SmartPointer<gdcm::DataElement> pixel_element = new gdcm::DataElement(...);
+pixel_element->SetByteValue(...);  // 포인터 저장 - 위험!
+```
+
+**문제점:**
+- SmartPointer가 DataElement를 관리하지만, SetByteValue()는 raw pointer 저장
+- pixel_data vector가 먼저 소멸하면 dangling pointer 발생 가능
+
+## 🔧 테스트 커스터마이징
+
+### test_dcm_memory.cpp 수정
+
+**테스트 케이스 추가:**
+```cpp
+// test_various_sizes() 함수에 추가
+TestCase test_cases[] = {
+    // ... 기존 케이스들
+    {"custom_200x200x100", {200, 200, 100}, 10000},  // 커스텀 케이스
+};
+```
+
+**반복 횟수 조정:**
+```cpp
+// main() 함수에서
+int iterations = 100;  // 기본값 변경
+```
+
+### Makefile 옵션 조정
+
+**최적화 레벨 변경:**
+```makefile
+CXXFLAGS = -std=c++11 -Wall -Wextra -g -O2  # -O2 추가
+```
+
+**추가 sanitizer 옵션:**
+```makefile
+asan: CXXFLAGS += -fsanitize=address,undefined  # undefined behavior 탐지 추가
+```
+
+## 📈 성능 측정
+
+### 실행 시간 비교
+```bash
+# Normal
+time ./test_dcm_memory 100
+
+# Valgrind (매우 느림, ~50-100배)
+time valgrind ./test_dcm_memory 100
+
+# ASAN (약간 느림, ~2-3배)
+time ./test_dcm_memory 100  # ASAN 빌드로
+```
+
+### 메모리 프로파일링
+```bash
+# Massif (힙 메모리 프로파일링)
+valgrind --tool=massif ./test_dcm_memory 50
+ms_print massif.out.*
+```
+
+## 🔬 디버깅 팁
+
+### 1. GDB로 크래시 위치 확인
+```bash
+gdb ./test_dcm_memory
+(gdb) run 10
+# 크래시 발생 시
+(gdb) bt        # backtrace
+(gdb) info locals
+(gdb) print pixel_data.size()
+```
+
+### 2. 특정 반복에서만 실패하는 경우
+```cpp
+// test_repeated_dcm_save에 추가
+if (i == 42) {  // 문제가 되는 반복 번호
+    std::cout << "Debug: About to call save_to_dcm" << std::endl;
+    // breakpoint 또는 추가 로깅
+}
+```
+
+### 3. GDCM 디버그 출력 활성화
+```cpp
+// main() 함수 시작 부분에 추가
+gdcm::Trace::SetDebug(true);
+gdcm::Trace::SetWarning(true);
+```
+
+## 📝 테스트 리포트 예시
+
+### 성공 케이스
+```
+=== Memory Information ===
+VmSize:    45678 kB
+VmRSS:     23456 kB
+VmPeak:    45678 kB
+
+=== Various Size Test ===
+✓ small_10x10x10 passed
+✓ medium_50x50x50 passed
+✓ large_100x100x50 passed
+✓ sparse_100x100x100 passed
+
+=== Repeated DICOM Save Test ===
+Progress: 0/50
+Progress: 10/50
+Progress: 20/50
+Progress: 30/50
+Progress: 40/50
+✓ All 50 iterations passed
+
+Valgrind:
+  ERROR SUMMARY: 0 errors from 0 contexts
+  All heap blocks were freed -- no leaks are possible
+```
+
+### 실패 케이스
+```
+=== Repeated DICOM Save Test ===
+Progress: 0/50
+Progress: 10/50
+free(): invalid size
+Aborted (core dumped)
+
+Valgrind:
+  Invalid free() / delete / delete[] / realloc()
+  Address 0x... is 0 bytes inside a block of size 1,000 alloc'd
+
+AddressSanitizer:
+  heap-use-after-free on address 0x...
+  freed by thread T0 here:
+    #0 in operator delete
+    #1 in std::vector<>::~vector()
+  previously allocated by thread T0 here:
+    #0 in operator new[]
+    #1 in std::vector<>::resize()
+```
+
+## 🆘 문제 해결 가이드
+
+### 빌드 오류
+
+**GDCM 헤더를 찾을 수 없음:**
+```bash
+# GDCM 설치 확인
+dpkg -l | grep gdcm
+locate gdcmImage.h
+
+# Makefile 수정
+INCLUDES = -I./moqui -I/usr/include/gdcm-3.0  # 경로 조정
+```
+
+**링크 오류:**
+```bash
+# GDCM 라이브러리 확인
+ldconfig -p | grep gdcm
+
+# 필요 시 LD_LIBRARY_PATH 설정
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+```
+
+### 런타임 오류
+
+**Segmentation fault:**
+```bash
+# Core dump 활성화
+ulimit -c unlimited
+
+# 크래시 후 분석
+gdb ./test_dcm_memory core
+```
+
+**Permission denied (출력 디렉토리):**
+```bash
+mkdir -p test_dcm_output
+chmod 755 test_dcm_output
+```
+
+## 📚 참고 자료
+
+### GDCM 문서
+- GDCM Wiki: http://gdcm.sourceforge.net/
+- API Documentation: http://gdcm.sourceforge.net/html/
+
+### 메모리 디버깅 도구
+- Valgrind Manual: https://valgrind.org/docs/manual/
+- AddressSanitizer: https://github.com/google/sanitizers/wiki/AddressSanitizer
+- GDB Manual: https://sourceware.org/gdb/documentation/
+
+### DICOM 표준
+- RT Dose Storage (1.2.840.10008.5.1.4.1.1.481.2)
+- DICOM Part 3: Information Object Definitions
+
+## 🤝 기여
+
+문제를 발견하거나 개선 사항이 있으면:
+1. 이슈 생성
+2. 테스트 케이스 추가
+3. Pull Request 제출
+
+---
+
+**작성일:** 2025-11-07
+**버전:** 1.0
+**테스트 대상:** moqui/base/mqi_io.hpp - save_to_dcm 함수

--- a/Makefile.test_dcm
+++ b/Makefile.test_dcm
@@ -1,0 +1,69 @@
+# Makefile for DICOM Memory Test
+# Usage:
+#   make -f Makefile.test_dcm        # Normal build
+#   make -f Makefile.test_dcm asan   # Build with AddressSanitizer
+#   make -f Makefile.test_dcm clean  # Clean build artifacts
+
+CXX = g++
+CXXFLAGS = -std=c++11 -Wall -Wextra -g
+INCLUDES = -I. -I/usr/include/gdcm-3.0
+LDFLAGS = -lgdcmCommon -lgdcmDICT -lgdcmDSED -lgdcmIOD -lgdcmMSFF -lz
+
+TARGET = test_dcm_memory
+SOURCE = test_dcm_memory.cpp
+
+# Default target: normal build
+all: $(TARGET)
+
+# Normal build
+$(TARGET): $(SOURCE)
+	@echo "Building $(TARGET)..."
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(SOURCE) -o $(TARGET) $(LDFLAGS)
+	@echo "Build complete: ./$(TARGET)"
+	@echo ""
+	@echo "Run with:"
+	@echo "  ./$(TARGET)                    # Normal execution"
+	@echo "  ./$(TARGET) 100                # Run 100 iterations"
+	@echo "  valgrind ./$(TARGET)           # Run with Valgrind"
+	@echo "  make -f Makefile.test_dcm asan # Build with AddressSanitizer"
+
+# Build with AddressSanitizer
+asan: CXXFLAGS += -fsanitize=address -fno-omit-frame-pointer
+asan: LDFLAGS += -fsanitize=address
+asan: clean $(TARGET)
+	@echo ""
+	@echo "AddressSanitizer build complete!"
+	@echo "Run with: ASAN_OPTIONS=detect_leaks=1 ./$(TARGET)"
+
+# Build with Valgrind-friendly flags
+valgrind: CXXFLAGS += -O0
+valgrind: clean $(TARGET)
+	@echo ""
+	@echo "Valgrind-optimized build complete!"
+	@echo "Run with: valgrind --leak-check=full --show-leak-kinds=all ./$(TARGET)"
+
+# Clean
+clean:
+	@echo "Cleaning..."
+	rm -f $(TARGET)
+	rm -rf test_dcm_output
+	@echo "Clean complete"
+
+# Test runs
+test: $(TARGET)
+	@echo "Running basic test..."
+	./$(TARGET)
+
+test-valgrind: $(TARGET)
+	@echo "Running with Valgrind..."
+	valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes \
+	         --log-file=valgrind_report.txt ./$(TARGET) 20
+	@echo "Valgrind report saved to: valgrind_report.txt"
+	@cat valgrind_report.txt
+
+test-asan: asan
+	@echo "Running with AddressSanitizer..."
+	ASAN_OPTIONS=detect_leaks=1:log_path=asan_report.txt ./$(TARGET) 20
+	@echo "AddressSanitizer report saved to: asan_report.txt.*"
+
+.PHONY: all asan valgrind clean test test-valgrind test-asan

--- a/TEST_QUICK_START.md
+++ b/TEST_QUICK_START.md
@@ -1,0 +1,258 @@
+# 🚀 DCM 메모리 테스트 빠른 시작 가이드
+
+## 📦 1단계: GDCM 라이브러리 설치
+
+### Ubuntu/Debian:
+```bash
+sudo apt-get update
+sudo apt-get install -y libgdcm-dev libgdcm-tools
+```
+
+### macOS:
+```bash
+brew install gdcm
+```
+
+### 설치 확인:
+```bash
+# GDCM 헤더 파일 확인
+ls /usr/include/gdcm*/gdcmDataElement.h
+
+# GDCM 라이브러리 확인
+ldconfig -p | grep gdcm
+```
+
+## 🔨 2단계: 테스트 빌드
+
+```bash
+cd /home/user/MOQUI_JKH
+
+# 기본 빌드
+make -f Makefile.test_dcm
+
+# 또는 AddressSanitizer 포함 빌드 (권장)
+make -f Makefile.test_dcm asan
+```
+
+## ▶️ 3단계: 테스트 실행
+
+### 방법 1: 자동화 스크립트 (가장 쉬움)
+```bash
+# 모든 테스트 자동 실행
+./run_dcm_memory_test.sh
+
+# 특정 테스트만 실행
+./run_dcm_memory_test.sh basic      # 기본 테스트
+./run_dcm_memory_test.sh valgrind   # Valgrind 메모리 체크
+./run_dcm_memory_test.sh asan       # AddressSanitizer
+./run_dcm_memory_test.sh stress     # 스트레스 테스트 (1000회 반복)
+```
+
+### 방법 2: 직접 실행
+```bash
+# 기본 실행 (50회 반복)
+./test_dcm_memory
+
+# 반복 횟수 지정
+./test_dcm_memory 100
+
+# Valgrind로 메모리 누수 검사
+valgrind --leak-check=full --show-leak-kinds=all ./test_dcm_memory 30
+
+# AddressSanitizer로 실행
+make -f Makefile.test_dcm asan
+ASAN_OPTIONS=detect_leaks=1 ./test_dcm_memory 30
+```
+
+## 📊 4단계: 결과 확인
+
+### 성공 케이스:
+```
+✓ All tests passed!
+
+Valgrind 결과:
+  ERROR SUMMARY: 0 errors from 0 contexts
+  All heap blocks were freed -- no leaks are possible
+```
+
+### 메모리 누수 발견:
+```
+Valgrind:
+  definitely lost: 1,024 bytes in 1 blocks
+  indirectly lost: 512 bytes in 2 blocks
+
+→ 리포트: test_reports/valgrind_report.txt 확인
+```
+
+### 메모리 Corruption 발견:
+```
+free(): invalid size
+*** stack smashing detected ***
+
+AddressSanitizer:
+  heap-use-after-free on address 0x...
+
+→ 리포트: test_reports/asan_report.* 확인
+```
+
+## 🐛 현재 알려진 문제
+
+### mqi_io.hpp의 save_to_dcm 함수 (라인 619-908)
+
+**문제점:**
+```cpp
+// 라인 765-767: SmartPointer 사용
+gdcm::SmartPointer<gdcm::DataElement> pixel_element =
+    new gdcm::DataElement(gdcm::Tag(0x7FE0, 0x0010));
+pixel_element->SetByteValue(
+    reinterpret_cast<const char*>(pixel_data.data()),
+    pixel_data_size);  // ← 포인터만 저장, 데이터 복사 안 함!
+
+ds.Insert(*pixel_element);
+```
+
+**문제 원인:**
+1. `SetByteValue()`는 `pixel_data.data()` 포인터만 저장
+2. `pixel_data` vector는 함수 끝에서 소멸
+3. GDCM이 소멸 시 이미 해제된 메모리를 접근 → **Dangling Pointer**
+4. "free(): invalid size" 또는 "heap-use-after-free" 발생
+
+**해결 방법:**
+
+#### 옵션 1: ByteValue 복사 생성 (권장)
+```cpp
+// SetByteValue 대신 복사본을 만들어서 사용
+gdcm::DataElement pixel_element(gdcm::Tag(0x7FE0, 0x0010));
+pixel_element.SetVR(gdcm::VR::OB);
+
+// 데이터 복사본 생성
+std::vector<char> pixel_copy(
+    reinterpret_cast<const char*>(pixel_data.data()),
+    reinterpret_cast<const char*>(pixel_data.data()) + pixel_data_size
+);
+pixel_element.SetByteValue(&pixel_copy[0], pixel_copy.size());
+
+// 또는 GDCM의 ByteValue를 직접 생성
+gdcm::ByteValue* bv = new gdcm::ByteValue(
+    reinterpret_cast<const char*>(pixel_data.data()),
+    pixel_data_size
+);
+pixel_element.SetValue(*bv);
+
+ds.Insert(pixel_element);
+```
+
+#### 옵션 2: pixel_data를 함수 스코프 밖으로 이동
+```cpp
+// pixel_data를 함수 스코프 끝까지 유지
+void save_to_dcm(...) {
+    std::vector<uint16_t> pixel_data;
+    // ... 데이터 준비 ...
+
+    gdcm::File file;
+    gdcm::DataSet& ds = file.GetDataSet();
+
+    // DataElement 생성 및 삽입
+    gdcm::DataElement pixel_element(gdcm::Tag(0x7FE0, 0x0010));
+    pixel_element.SetByteValue(...);
+    ds.Insert(pixel_element);
+
+    // Writer 생성 및 저장
+    gdcm::Writer writer;
+    writer.SetFile(file);
+    writer.Write();
+
+    // pixel_data는 여기서 소멸 (Writer.Write() 이후이므로 안전)
+}
+```
+
+## 📁 생성된 파일 구조
+
+```
+MOQUI_JKH/
+├── test_dcm_memory.cpp           ← 메인 테스트 코드
+├── Makefile.test_dcm             ← 빌드 설정
+├── run_dcm_memory_test.sh        ← 자동화 스크립트
+├── DCM_MEMORY_TEST_README.md     ← 상세 문서
+├── TEST_QUICK_START.md           ← 이 파일
+│
+├── test_dcm_output/              ← 생성된 DICOM 파일 (자동 생성)
+└── test_reports/                 ← 테스트 리포트 (자동 생성)
+    ├── valgrind_report.txt
+    └── asan_report.*
+```
+
+## 💡 유용한 명령어
+
+### 빌드 관련
+```bash
+make -f Makefile.test_dcm          # 일반 빌드
+make -f Makefile.test_dcm asan     # AddressSanitizer 빌드
+make -f Makefile.test_dcm clean    # 클린
+```
+
+### 테스트 실행
+```bash
+./test_dcm_memory                  # 기본 (50회)
+./test_dcm_memory 200              # 200회 반복
+```
+
+### 메모리 분석
+```bash
+# Valgrind 상세 분석
+valgrind --leak-check=full \
+         --show-leak-kinds=all \
+         --track-origins=yes \
+         --verbose \
+         --log-file=valgrind_full.txt \
+         ./test_dcm_memory 50
+
+# AddressSanitizer 상세 옵션
+ASAN_OPTIONS="detect_leaks=1:print_stats=1:atexit=1" \
+    ./test_dcm_memory 50
+
+# 메모리 사용량 모니터링
+watch -n 1 'ps aux | grep test_dcm_memory | grep -v grep'
+```
+
+### GDB 디버깅
+```bash
+gdb ./test_dcm_memory
+(gdb) run 10
+# 크래시 발생 시
+(gdb) bt              # 백트레이스
+(gdb) frame 0         # 크래시 프레임 확인
+(gdb) print pixel_data.size()
+(gdb) info locals    # 로컬 변수 확인
+```
+
+## 🎯 다음 단계
+
+### 문제가 발견되면:
+1. **리포트 확인**: `test_reports/` 디렉토리의 상세 리포트 분석
+2. **코드 수정**: `moqui/base/mqi_io.hpp`의 `save_to_dcm` 함수 수정
+3. **재테스트**: 수정 후 다시 테스트 실행
+4. **커밋**: 문제 해결 후 git commit
+
+### 문제가 없으면:
+1. 더 많은 반복으로 재테스트 (1000회 이상)
+2. 더 큰 데이터로 스트레스 테스트
+3. 다양한 입력 케이스 추가
+
+## 📞 도움말
+
+### 더 자세한 정보:
+```bash
+cat DCM_MEMORY_TEST_README.md    # 전체 문서
+./run_dcm_memory_test.sh help    # 스크립트 도움말
+```
+
+### 문제 발생 시:
+1. GDCM 설치 확인: `dpkg -l | grep gdcm`
+2. 헤더 파일 확인: `find /usr -name "gdcmDataElement.h"`
+3. 라이브러리 확인: `ldconfig -p | grep gdcm`
+
+---
+
+**생성 날짜**: 2025-11-07
+**목적**: mqi_io.hpp save_to_dcm 메모리 문제 진단

--- a/run_dcm_memory_test.sh
+++ b/run_dcm_memory_test.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# DICOM Memory Test Runner Script
+# 이 스크립트는 다양한 메모리 분석 도구로 테스트를 실행합니다.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "========================================="
+echo "DICOM Memory Test Runner"
+echo "========================================="
+echo ""
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_section() {
+    echo ""
+    echo -e "${BLUE}=========================================${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}=========================================${NC}"
+    echo ""
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠ $1${NC}"
+}
+
+# 빌드 확인
+if [ ! -f "./test_dcm_memory" ]; then
+    print_warning "Test binary not found. Building..."
+    make -f Makefile.test_dcm
+fi
+
+# 출력 디렉토리 생성
+mkdir -p test_dcm_output
+mkdir -p test_reports
+
+# 테스트 모드 선택
+MODE=${1:-"all"}
+ITERATIONS=${2:-"30"}
+
+case $MODE in
+    "basic"|"1")
+        print_section "Test 1: Basic Execution"
+        ./test_dcm_memory $ITERATIONS
+        print_success "Basic test completed"
+        ;;
+
+    "valgrind"|"2")
+        print_section "Test 2: Valgrind Memory Check"
+        if ! command -v valgrind &> /dev/null; then
+            print_error "Valgrind not found. Install with: sudo apt-get install valgrind"
+            exit 1
+        fi
+
+        print_warning "Running Valgrind (this may take a while)..."
+        valgrind --leak-check=full \
+                 --show-leak-kinds=all \
+                 --track-origins=yes \
+                 --verbose \
+                 --log-file=test_reports/valgrind_report.txt \
+                 ./test_dcm_memory $ITERATIONS
+
+        print_success "Valgrind test completed"
+        echo "Report saved to: test_reports/valgrind_report.txt"
+        echo ""
+        echo "Summary:"
+        grep -E "ERROR SUMMARY|definitely lost|indirectly lost|possibly lost" test_reports/valgrind_report.txt || true
+        ;;
+
+    "asan"|"3")
+        print_section "Test 3: AddressSanitizer Check"
+        print_warning "Rebuilding with AddressSanitizer..."
+        make -f Makefile.test_dcm asan
+
+        print_warning "Running with AddressSanitizer..."
+        ASAN_OPTIONS="detect_leaks=1:log_path=test_reports/asan_report:print_stats=1" \
+            ./test_dcm_memory $ITERATIONS
+
+        print_success "AddressSanitizer test completed"
+        if ls test_reports/asan_report.* 1> /dev/null 2>&1; then
+            echo "Report saved to: test_reports/asan_report.*"
+            echo ""
+            echo "Summary:"
+            cat test_reports/asan_report.* 2>/dev/null || true
+        else
+            print_success "No memory issues detected by AddressSanitizer!"
+        fi
+        ;;
+
+    "stress"|"4")
+        print_section "Test 4: Stress Test (Many Iterations)"
+        STRESS_ITERATIONS=${2:-"1000"}
+        print_warning "Running $STRESS_ITERATIONS iterations..."
+        ./test_dcm_memory $STRESS_ITERATIONS
+        print_success "Stress test completed"
+        ;;
+
+    "all"|"5")
+        print_section "Running All Tests"
+
+        # Test 1: Basic
+        print_section "Test 1/4: Basic Execution"
+        ./test_dcm_memory 20
+        print_success "Basic test passed"
+
+        # Test 2: Valgrind (if available)
+        if command -v valgrind &> /dev/null; then
+            print_section "Test 2/4: Valgrind Check"
+            print_warning "Running Valgrind with reduced iterations..."
+            valgrind --leak-check=full \
+                     --show-leak-kinds=all \
+                     --log-file=test_reports/valgrind_report.txt \
+                     ./test_dcm_memory 10
+
+            print_success "Valgrind test completed"
+            echo "Report: test_reports/valgrind_report.txt"
+            grep -E "ERROR SUMMARY|definitely lost|indirectly lost" test_reports/valgrind_report.txt || true
+        else
+            print_warning "Skipping Valgrind (not installed)"
+        fi
+
+        # Test 3: AddressSanitizer
+        print_section "Test 3/4: AddressSanitizer Check"
+        make -f Makefile.test_dcm asan
+        ASAN_OPTIONS="detect_leaks=1:log_path=test_reports/asan_report" \
+            ./test_dcm_memory 10
+        print_success "AddressSanitizer test completed"
+
+        # Test 4: Stress test
+        print_section "Test 4/4: Stress Test"
+        make -f Makefile.test_dcm  # Rebuild without ASAN for speed
+        ./test_dcm_memory 100
+        print_success "Stress test completed"
+
+        print_section "All Tests Completed!"
+        print_success "Check test_reports/ directory for detailed reports"
+        ;;
+
+    "clean")
+        print_section "Cleaning Test Artifacts"
+        make -f Makefile.test_dcm clean
+        rm -rf test_reports
+        print_success "Cleaned"
+        ;;
+
+    "help"|"-h"|"--help")
+        echo "Usage: $0 [mode] [iterations]"
+        echo ""
+        echo "Modes:"
+        echo "  basic, 1        - Basic execution test (default: 30 iterations)"
+        echo "  valgrind, 2     - Run with Valgrind memory checker"
+        echo "  asan, 3         - Run with AddressSanitizer"
+        echo "  stress, 4       - Stress test with many iterations (default: 1000)"
+        echo "  all, 5          - Run all tests (default)"
+        echo "  clean           - Clean build and test artifacts"
+        echo "  help            - Show this help"
+        echo ""
+        echo "Examples:"
+        echo "  $0                      # Run all tests"
+        echo "  $0 basic 50             # Run basic test with 50 iterations"
+        echo "  $0 valgrind 20          # Run Valgrind with 20 iterations"
+        echo "  $0 stress 2000          # Stress test with 2000 iterations"
+        ;;
+
+    *)
+        print_error "Unknown mode: $MODE"
+        echo "Run '$0 help' for usage information"
+        exit 1
+        ;;
+esac
+
+echo ""
+print_section "Test Run Complete"

--- a/test_dcm_memory.cpp
+++ b/test_dcm_memory.cpp
@@ -1,0 +1,274 @@
+/**
+ * @file test_dcm_memory.cpp
+ * @brief DICOM save 메모리 관리 문제 테스트 프로그램
+ *
+ * 이 테스트는 mqi::io::save_to_dcm 함수의 메모리 관리 문제를 감지하기 위해 설계되었습니다.
+ *
+ * 테스트 목적:
+ * 1. save_to_dcm 함수 호출 시 메모리 누수/corruption 확인
+ * 2. 반복 호출 시 메모리 문제 재현
+ * 3. 다양한 크기의 데이터로 테스트
+ *
+ * 실행 방법:
+ * - 일반 실행: ./test_dcm_memory
+ * - Valgrind: valgrind --leak-check=full --show-leak-kinds=all ./test_dcm_memory
+ * - AddressSanitizer: ASAN_OPTIONS=detect_leaks=1 ./test_dcm_memory
+ *
+ * 컴파일 방법:
+ * g++ -std=c++11 -I./moqui -I/usr/include/gdcm-3.0 \
+ *     test_dcm_memory.cpp -o test_dcm_memory \
+ *     -lgdcmCommon -lgdcmDICT -lgdcmDSED -lgdcmIOD -lgdcmMSFF \
+ *     -lz -fsanitize=address -g
+ */
+
+#include <iostream>
+#include <cstring>
+#include <cstdlib>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <moqui/base/mqi_io.hpp>
+#include <moqui/base/mqi_scorer.hpp>
+#include <moqui/base/mqi_hash_table.hpp>
+#include <moqui/base/mqi_vec.hpp>
+#include <moqui/base/mqi_track.hpp>
+#include <moqui/base/mqi_grid3d.hpp>
+
+// 테스트용 더미 함수
+template<typename R>
+double dummy_compute_hit(const mqi::track_t<R>&, const mqi::cnb_t&, mqi::grid3d<mqi::density_t, R>&) {
+    return 0.0;
+}
+
+/**
+ * @brief 테스트용 scorer 객체 생성
+ * @param dim 3D 차원
+ * @param num_entries 채울 데이터 엔트리 수
+ * @return scorer 객체 포인터 (사용 후 반드시 delete 필요)
+ */
+template<typename R>
+mqi::scorer<R>* create_test_scorer(const mqi::vec3<mqi::ijk_t>& dim, uint32_t num_entries) {
+    uint32_t capacity = num_entries * 2;  // 해시 테이블 효율을 위해 2배 크기 할당
+
+    // Scorer 생성
+    auto* scorer = new mqi::scorer<R>("test_dose", capacity, dummy_compute_hit<R>);
+    scorer->type_ = mqi::DOSE;
+    scorer->roi_ = nullptr;
+
+    // 데이터 할당
+    scorer->data_ = new mqi::key_value[capacity];
+
+    // 초기화
+    for (uint32_t i = 0; i < capacity; i++) {
+        scorer->data_[i].key1 = mqi::empty_pair;
+        scorer->data_[i].key2 = mqi::empty_pair;
+        scorer->data_[i].value = 0.0;
+    }
+
+    // 테스트 데이터 채우기
+    uint32_t vol_size = dim.x * dim.y * dim.z;
+    for (uint32_t i = 0; i < num_entries && i < capacity; i++) {
+        scorer->data_[i].key1 = i % vol_size;  // voxel index
+        scorer->data_[i].key2 = 0;              // spot index (단일 spot)
+        scorer->data_[i].value = 1.0 + (i % 100) / 100.0;  // 1.0 ~ 1.99 범위 dose
+    }
+
+    return scorer;
+}
+
+/**
+ * @brief 단일 DICOM save 테스트
+ * @param test_name 테스트 이름
+ * @param dim 3D 차원
+ * @param num_entries 데이터 엔트리 수
+ * @return 성공 여부
+ */
+bool test_single_dcm_save(const char* test_name,
+                          const mqi::vec3<mqi::ijk_t>& dim,
+                          uint32_t num_entries) {
+    std::cout << "\n=== " << test_name << " ===" << std::endl;
+    std::cout << "Dimension: (" << dim.x << ", " << dim.y << ", " << dim.z << ")" << std::endl;
+    std::cout << "Entries: " << num_entries << std::endl;
+
+    // Scorer 생성
+    auto* scorer = create_test_scorer<float>(dim, num_entries);
+
+    // 출력 디렉토리 생성
+    std::string output_dir = "./test_dcm_output";
+    mkdir(output_dir.c_str(), 0755);
+
+    // DICOM 저장
+    std::string filename = std::string(test_name);
+    uint32_t length = dim.x * dim.y * dim.z;
+
+    try {
+        mqi::io::save_to_dcm(scorer, 1.0f, output_dir, filename, length, dim, false);
+        std::cout << "✓ DICOM save completed" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "✗ Exception: " << e.what() << std::endl;
+        delete scorer;
+        return false;
+    }
+
+    // Scorer 삭제 (메모리 해제)
+    delete scorer;
+
+    std::cout << "✓ Test passed" << std::endl;
+    return true;
+}
+
+/**
+ * @brief 반복 DICOM save 테스트 (메모리 누수 감지용)
+ * @param iterations 반복 횟수
+ * @return 성공 여부
+ */
+bool test_repeated_dcm_save(int iterations) {
+    std::cout << "\n=== Repeated DICOM Save Test (Memory Leak Detection) ===" << std::endl;
+    std::cout << "Iterations: " << iterations << std::endl;
+
+    mqi::vec3<mqi::ijk_t> dim = {50, 50, 50};
+    uint32_t num_entries = 1000;
+
+    for (int i = 0; i < iterations; i++) {
+        if (i % 10 == 0) {
+            std::cout << "Progress: " << i << "/" << iterations << std::endl;
+        }
+
+        auto* scorer = create_test_scorer<float>(dim, num_entries);
+
+        std::string output_dir = "./test_dcm_output";
+        std::string filename = "repeated_test_" + std::to_string(i);
+        uint32_t length = dim.x * dim.y * dim.z;
+
+        try {
+            mqi::io::save_to_dcm(scorer, 1.0f, output_dir, filename, length, dim, false);
+        } catch (const std::exception& e) {
+            std::cerr << "✗ Exception at iteration " << i << ": " << e.what() << std::endl;
+            delete scorer;
+            return false;
+        }
+
+        delete scorer;
+
+        // 생성된 파일 삭제 (디스크 공간 절약)
+        std::string dcm_file = output_dir + "/" + filename + ".dcm";
+        unlink(dcm_file.c_str());
+    }
+
+    std::cout << "✓ All " << iterations << " iterations passed" << std::endl;
+    return true;
+}
+
+/**
+ * @brief 다양한 크기로 DICOM save 테스트
+ * @return 성공 여부
+ */
+bool test_various_sizes() {
+    std::cout << "\n=== Various Size Test ===" << std::endl;
+
+    struct TestCase {
+        const char* name;
+        mqi::vec3<mqi::ijk_t> dim;
+        uint32_t entries;
+    };
+
+    TestCase test_cases[] = {
+        {"small_10x10x10",   {10, 10, 10},     100},
+        {"medium_50x50x50",  {50, 50, 50},     1000},
+        {"large_100x100x50", {100, 100, 50},   5000},
+        {"sparse_100x100x100", {100, 100, 100}, 1000},  // sparse data
+    };
+
+    for (const auto& tc : test_cases) {
+        if (!test_single_dcm_save(tc.name, tc.dim, tc.entries)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * @brief 메모리 스트레스 테스트 (큰 데이터)
+ * @return 성공 여부
+ */
+bool test_large_data() {
+    std::cout << "\n=== Large Data Stress Test ===" << std::endl;
+
+    mqi::vec3<mqi::ijk_t> dim = {256, 256, 128};  // 8M voxels
+    uint32_t num_entries = 50000;  // 50K non-zero entries
+
+    std::cout << "Total voxels: " << (dim.x * dim.y * dim.z) << std::endl;
+    std::cout << "Memory size: ~" << (dim.x * dim.y * dim.z * sizeof(uint16_t) / 1024 / 1024) << " MB" << std::endl;
+
+    return test_single_dcm_save("large_256x256x128", dim, num_entries);
+}
+
+/**
+ * @brief 메모리 상태 출력 (Linux procfs 이용)
+ */
+void print_memory_info() {
+    std::cout << "\n=== Memory Information ===" << std::endl;
+
+    // /proc/self/status에서 메모리 정보 읽기
+    FILE* fp = fopen("/proc/self/status", "r");
+    if (!fp) return;
+
+    char line[256];
+    while (fgets(line, sizeof(line), fp)) {
+        if (strncmp(line, "VmSize:", 7) == 0 ||
+            strncmp(line, "VmRSS:", 6) == 0 ||
+            strncmp(line, "VmPeak:", 7) == 0) {
+            std::cout << line;
+        }
+    }
+    fclose(fp);
+}
+
+int main(int argc, char* argv[]) {
+    std::cout << "========================================" << std::endl;
+    std::cout << "DICOM Save Memory Test Program" << std::endl;
+    std::cout << "========================================" << std::endl;
+
+    print_memory_info();
+
+    bool all_passed = true;
+
+    // 테스트 1: 다양한 크기
+    if (!test_various_sizes()) {
+        all_passed = false;
+        std::cerr << "✗ Various sizes test failed" << std::endl;
+    }
+
+    print_memory_info();
+
+    // 테스트 2: 반복 테스트 (메모리 누수 감지)
+    int iterations = 50;
+    if (argc > 1) {
+        iterations = atoi(argv[1]);
+    }
+    if (!test_repeated_dcm_save(iterations)) {
+        all_passed = false;
+        std::cerr << "✗ Repeated test failed" << std::endl;
+    }
+
+    print_memory_info();
+
+    // 테스트 3: 큰 데이터 스트레스 테스트
+    if (!test_large_data()) {
+        all_passed = false;
+        std::cerr << "✗ Large data test failed" << std::endl;
+    }
+
+    print_memory_info();
+
+    std::cout << "\n========================================" << std::endl;
+    if (all_passed) {
+        std::cout << "✓ All tests passed!" << std::endl;
+        std::cout << "Note: Run with Valgrind or AddressSanitizer for memory leak detection" << std::endl;
+        return 0;
+    } else {
+        std::cout << "✗ Some tests failed!" << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
Add test code to diagnose and reproduce memory management issues in mqi::io::save_to_dcm function when saving DICOM files.

Test Components:
- test_dcm_memory.cpp: Main test program with multiple test cases
  * Various size tests (10x10x10 to 256x256x128)
  * Repeated save test (configurable iterations)
  * Memory stress test with large datasets
  * Memory usage monitoring via /proc/self/status

- Makefile.test_dcm: Build configuration
  * Normal build target
  * AddressSanitizer build (detect memory corruption)
  * Valgrind-optimized build
  * Automated test targets (test, test-valgrind, test-asan)

- run_dcm_memory_test.sh: Automated test runner script
  * Multiple test modes (basic, valgrind, asan, stress, all)
  * Colored output for test results
  * Automated report generation

- DCM_MEMORY_TEST_README.md: Comprehensive documentation
  * Detailed usage instructions
  * Known issues and solutions
  * Debugging tips and troubleshooting guide
  * Expected test results and interpretation

- TEST_QUICK_START.md: Quick start guide
  * Installation instructions for GDCM library
  * Step-by-step test execution guide
  * Analysis of current memory issues in save_to_dcm
  * Recommended fix options

Purpose:
This test suite helps identify memory corruption issues in save_to_dcm, specifically the "free(): invalid size" error caused by:
1. SetByteValue() storing only pointer to std::vector data
2. std::vector destructing before GDCM releases the pointer
3. Allocator mismatch between C++ new[] and C free()

Usage:
  ./run_dcm_memory_test.sh        # Run all tests
  ./run_dcm_memory_test.sh asan   # AddressSanitizer test
  ./test_dcm_memory 100           # 100 iterations

Issue: Memory management in dcm_save function
Target: moqui/base/mqi_io.hpp (save_to_dcm, lines 619-908)